### PR TITLE
Alpha stabilization part 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -265,7 +265,6 @@ path = "src/closest-pair.rs"
 # http://rosettacode.org/wiki/Closures/Value_capture
 name = "closures-value_capture"
 path = "src/closures-value_capture.rs"
-test = false
 
 [[bin]]
 # http://rosettacode.org/wiki/Comma_quibbling

--- a/src/closures-value_capture.rs
+++ b/src/closures-value_capture.rs
@@ -1,19 +1,47 @@
 // http://rosettacode.org/wiki/Closures/Value_capture
-
-#![feature(unboxed_closures)]
-
-use std::iter::count;
+#[allow(unstable)]
+use std::iter::{count, Counter, Map};
 use std::num::Float;
 
-fn main() {
-    // An infinite iterator that generates closures
-    let closures = count(0us, 1).map(|x| move |:| (x as f64).powi(2));
+// given a number x, return the (boxed) closure that
+// computes x squared
+fn closure_gen<'a>(x: u32) -> Box<Fn() -> f64 + 'a> {
+    Box::new(move |&:| (x as f64).powi(2))
+}
 
+// type alias for the closure iterator
+type ClosureIter<'a> = Map<u32, Box<Fn() -> f64 + 'a>, Counter<u32>, fn(u32) -> Box<Fn() -> f64 + 'a>>;
+
+// return an iterator that on every iteration returns
+// a closure computing the index of the iteration squared
+fn closures_iterator<'a>() -> ClosureIter<'a> {
+    let cl_gen : fn(u32) -> Box<Fn() -> f64 + 'a> = closure_gen;
+    count(0, 1).map(cl_gen)
+}
+
+#[cfg(not(test))]
+fn main() {
     // Take the first 9 closures from the iterator and call them
-    for c in closures.take(9) {
+    for c in closures_iterator().take(9) {
         println!("{}", c())
     }
 }
 
-// FIXME: add a function that returns an iterator over unboxed closures
-// (blocked by the lack of anonymous types)
+#[cfg(test)]
+mod test {
+    use std::num::Float;
+    use super::{closure_gen, closures_iterator};
+
+    #[test]
+    fn closure_generator() {
+        let five_squarer = closure_gen(5);
+        assert!(five_squarer() == 25f64);
+    }
+
+    #[test]
+    fn closure_iterator() {
+        for (idx, f) in closures_iterator().take(9).enumerate() {
+            assert!(f() == (idx as f64).powi(2));
+        }
+    }
+}

--- a/src/closures-value_capture.rs
+++ b/src/closures-value_capture.rs
@@ -1,5 +1,5 @@
 // http://rosettacode.org/wiki/Closures/Value_capture
-#[allow(unstable)]
+#![allow(unstable)]
 use std::iter::{count, Counter, Map};
 use std::num::Float;
 

--- a/src/function_composition.rs
+++ b/src/function_composition.rs
@@ -1,37 +1,23 @@
 // http://rosettacode.org/wiki/Function_composition
-
-// TODO: decide what to do for 1.0
-// the manual implementation of Fn traits for a struct
-// as done here for Composed is not going to be un-feature-gated
-// for 1.0 (so it's going to work only with the Rust nightlies)
-#![feature(unboxed_closures)]
-
+#![allow(unstable)]
 #[cfg(not(test))]
 fn main() {
     use std::f32::consts;
 
-    fn f(x: usize) -> String { x.to_string() }
-    fn g(x: f32) -> usize { x as usize }
-    
-    let comp = Composed::new(f, g);
-    
-    println!("{}", comp(consts::PI));
+    // the two functions we will compose:
+    let f = |&: x: u32| x.to_string();
+    let g = |&: x: f32| x as u32;
+
+    // their omposition
+    let comp = compose(f, g);
+
+    println!("{:?}", (*comp)(consts::PI));
 }
 
-struct Composed<A, B, C, F1, F2> 
-    where F1: Fn(A) -> B, F2: Fn(C) -> A {
-    f: F1,
-    g: F2
-}
-
-impl <A, B, C, F1, F2> Composed<A, B, C, F1, F2> 
-    where F1: Fn(A) -> B, F2: Fn(C) -> A {
-    fn new(f: F1, g: F2) -> Composed<A, B, C, F1, F2> { Composed{f: f, g: g} }
-}
-
-impl<A, B, C, F1, F2> Fn<(C,), B> for Composed<A, B, C, F1, F2> 
-    where F1: Fn(A) -> B, F2: Fn(C) -> A {
-    extern "rust-call" fn call(&self, (x,): (C,)) -> B { self.f.call((self.g.call((x,)),)) }
+fn compose<'a, F, G, A, B, C>(f: F, g: G) -> Box<Fn(A) -> C + 'a>
+    where G: Fn(A) -> B + 'a, F: Fn(B) -> C + 'a
+{
+    Box::new( move |&: a: A| f(g(a)) )
 }
 
 #[test]
@@ -39,6 +25,6 @@ fn test_compose() {
     fn inc(x: usize) -> usize { x + 1 }
     fn mul(x: usize) -> usize { x * 3 }
 
-    let comp = Composed::new(inc, mul);
-    assert_eq!(comp(3), 10);
+    let comp = compose(inc, mul);
+    assert_eq!((*comp)(3), 10);
 }

--- a/src/function_composition.rs
+++ b/src/function_composition.rs
@@ -8,7 +8,7 @@ fn main() {
     let f = |&: x: u32| x.to_string();
     let g = |&: x: f32| x as u32;
 
-    // their omposition
+    // their composition
     let comp = compose(f, g);
 
     println!("{:?}", (*comp)(consts::PI));

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,4 +1,6 @@
 // http://rosettacode.org/wiki/HTTP
+#![allow(unstable)]
+
 use std::io::net::tcp::TcpStream;
 use std::io::IoResult;
 
@@ -25,7 +27,7 @@ fn main() {
 
     let target = std::os::args().pop().unwrap();
     println!("Making the request... This might take a minute.");
-    match get_index(target.as_slice(), PORT) {
+    match get_index(&target[], PORT) {
         Ok(out) => println!("{}", out),
         Err(e) => println!("Error: {}", e)
     }

--- a/src/json.rs
+++ b/src/json.rs
@@ -1,11 +1,7 @@
 // Implements http://rosettacode.org/wiki/JSON
-
-// work around 
-// https://github.com/nikomatsakis/rust/commit/c61a0092bc236c4be4cb691fcd50ff50e91ab0d6
-#![feature(old_orphan_check)] 
+#![allow(unstable)]
 
 extern crate "rustc-serialize" as rustc_serialize;
-
 use rustc_serialize::json;
 
 #[derive(Show, RustcEncodable, RustcDecodable, PartialEq, Eq)]

--- a/src/taxicab_numbers.rs
+++ b/src/taxicab_numbers.rs
@@ -1,6 +1,5 @@
 // http://rosettacode.org/wiki/Taxicab_numbers
-#![feature(associated_types)]
-
+#![allow(unstable)]
 use std::collections::BinaryHeap;
 use std::num::Int;
 use std::cmp::Ordering;

--- a/src/walk_recursive.rs
+++ b/src/walk_recursive.rs
@@ -1,8 +1,7 @@
 // Implements http://rosettacode.org/wiki/Walk_a_directory/Recursively
+#![allow(unstable)]
 
 #![feature(plugin)]
-
-#[macro_use]
 #[plugin]
 extern crate regex_macros;
 extern crate regex;

--- a/src/webserver.rs
+++ b/src/webserver.rs
@@ -1,4 +1,5 @@
 // Implements http://rosettacode.org/wiki/Hello_world/Web_server
+#![allow(unstable)]
 
 use std::io::net::tcp::{TcpAcceptor, TcpListener, TcpStream};
 use std::io::{Acceptor, Listener, IoResult};

--- a/src/word_wrap.rs
+++ b/src/word_wrap.rs
@@ -1,11 +1,9 @@
 // http://rosettacode.org/wiki/Word_wrap
-
+#![allow(unstable)]
 // Using the minimum length greedy algorithm
 // http://en.wikipedia.org/wiki/Word_wrap#Minimum_length
 
 // Implemented as a lazy String iterator, returning a wrapped line each time
-#![feature(associated_types)]
-
 use std::str::Words;
 use std::mem::swap;
 
@@ -76,14 +74,13 @@ fn main () {
          took a golden ball, and threw it up on high and caught it, and this \
          ball was her favorite plaything.";
 
-    for &length in [72u, 80u].iter() {
+    for length in 72..81 {
         println!("Text wrapped at {}", length);
         for line in WordWrap::new(text, length) {
             println!("{}", line);
         }
         println!("");
     }
-
 }
 
 #[test]

--- a/src/write_ppm.rs
+++ b/src/write_ppm.rs
@@ -1,10 +1,7 @@
 // Implements http://rosettacode.org/wiki/Write_ppm_file
-#![feature(associated_types)]
-
+#![allow(unstable)]
 use std::io::{File, BufferedWriter, IoResult};
 use bitmap::Image;
-#[cfg(not(test))]
-use bitmap::Color;
 mod bitmap;
 
 trait PPMWritable {
@@ -28,6 +25,8 @@ impl PPMWritable for Image {
 
 #[cfg(not(test))]
 pub fn main() {
+    use bitmap::Color;
+
     // write a PPM image, the left side of which is red, and the right side
     // of which is blue
     let mut image = Image::new(64, 64);


### PR DESCRIPTION
I'm now going one by one through the tasks to try removing feature gates, to minimize the number of tasks that will stop working at 1.0.
In the case of function_composition, where the current solution is inherently unstable (we already know direct implementation of Fn traits will still be feature-gated at 1.0), I rewrote the solution with Boxed unboxed closures.

I'm also sprinkling `#![allow(unstable)]` to silence the warnings that are making it hard to follow compilation output and travis logs. For the warnings where a specific direction is suggested (like for ranges or some stray i/u suffixes) I try following the suggestion before silencing the others.

For the others (the one that just say that a method is not yet stable), adding a `#![allow(unstable)]` means that if/when those APIs change, these tasks will just break, of course. But that's just how it has been until today, and being warned about them on every build is only adding noise. But feel free to object!

