### PR TITLE
Iterator protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 name = "rust-rosetta"
 version = "0.0.1"
 dependencies = [
- "num 0.1.12 (git+https://github.com/rust-lang/num)",
+ "num 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex_macros 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -22,7 +22,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "num"
 version = "0.1.12"
-source = "git+https://github.com/rust-lang/num#0811c72bacce6d8adc7a25be8292ba55f4118d9e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rustc-serialize 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/src/24_game_solve.rs
+++ b/src/24_game_solve.rs
@@ -30,7 +30,7 @@ fn solve(r: &mut[Rational], target_val: isize) -> Option<String> {
     r.sort();
     loop {
         let all_ops = compute_all_operations(r);
-        for &(res, ref ops) in all_ops.iter() {
+        for &(res, ref ops) in &all_ops {
             if res==Ratio::from_integer(target_val) {return Some(ops.to_string());}
         }
         if ! r.next_permutation() {return None;}
@@ -47,10 +47,10 @@ fn compute_all_operations(l: &[Rational]) -> Vec<(Rational, String)> {
         [x]  => vec![(x, (format!("{}", x)))],
         [x,rest..] => {
             let mut rt=Vec::new();
-            for &(y, ref exp) in compute_all_operations(rest).iter() {
+            for &(y, ref exp) in &compute_all_operations(rest) {
                 let mut sub=vec![(x * y, "*"),(x + y, "+"), (x - y, "-")];
                 if y != Zero::zero() {sub.push( (x/y, "/")); }
-                for &(z, ref op) in sub.iter() {
+                for &(z, ref op) in &sub {
                     let aux = (z, (format!("({} {} {})", x, op, exp )));
                     rt.push(aux);
                 }

--- a/src/9_billion_names_of_God_the_integer.rs
+++ b/src/9_billion_names_of_God_the_integer.rs
@@ -63,7 +63,7 @@ fn main() {
     }
 
     println!("sums");
-    for &y in [23us, 123, 1234, 12345].iter() {
+    for &y in &[23us, 123, 1234, 12345] {
         println!("{}: {}", y, solver.row_sum(y));
     }
 }

--- a/src/abc_problem.rs
+++ b/src/abc_problem.rs
@@ -14,12 +14,12 @@ const  BLOCKS: &'static [&'static str] = &["BO", "XK", "DQ", "CP", "NA",
 #[cfg(not(test))]
 fn main() {
     println!("******\nmethod 1\n******");
-    for word in WORDS.iter() {
+    for word in WORDS {
         println!("can {} be built? {}", word, can_be_built_input_first(*word))
     }
 
     println!("\n******\nmethod 2\n******");
-    for word in WORDS.iter() {
+    for word in WORDS {
         println!("can {} be built? {}", word, can_be_built_blocks_first(*word))
     }
 }

--- a/src/align_columns.rs
+++ b/src/align_columns.rs
@@ -74,7 +74,7 @@ fn print_aligned_columns(chunks: &Vec<Vec<String>>, max_lengths: &Vec<usize>) {
 #[test]
 fn test_result() {
     let (chunks, max_lengths) = align_columns(TEST_STR);
-    for chunkset in chunks.iter() {
+    for chunkset in &chunks {
         // the number of words in a chunkset is <= the number of values in max_lengths
         assert!(chunkset.len() <= max_lengths.len());
         for j in (0us..chunkset.len()) {

--- a/src/arithmetic_rational.rs
+++ b/src/arithmetic_rational.rs
@@ -10,7 +10,7 @@ use std::ops::{Add, Mul, Neg, Sub, Div};
 
 #[cfg(not(test))]
 fn main() {
-    for p in perfect_numbers(1 << 19).iter() {
+    for p in perfect_numbers(1 << 19) {
         println!("{} is perfect", p);
     }
 }

--- a/src/benford.rs
+++ b/src/benford.rs
@@ -32,7 +32,7 @@ fn benford_distrib(numbers: &[u64]) -> Vec<f32> {
 
     let mut counts = [0u64; 10];
 
-    for num in numbers.iter() {
+    for num in numbers {
         let first = first_digit_of(*num);
         counts[first] += 1;
     }

--- a/src/bitmap.rs
+++ b/src/bitmap.rs
@@ -41,8 +41,8 @@ impl Image {
         let mut writer = BufferedWriter::new(file);
         try!(writer.write_line("P6"));
         try!(write!(&mut writer, "{} {} {}\n", self.width, self.height, 255us));
-        for color in self.data.iter() {
-            for channel in [color.red, color.green, color.blue].iter() {
+        for color in &(self.data) {
+            for channel in &[color.red, color.green, color.blue] {
                 try!(writer.write_u8(*channel));
             }
         }

--- a/src/bulls_and_cows.rs
+++ b/src/bulls_and_cows.rs
@@ -92,11 +92,11 @@ fn main() {
                  NUMBER_OF_DIGITS);
         loop {
             let guess_string = reader.read_line().unwrap();
-            let digits_maybe = parse_guess_string(&*guess_string.trim());
+            let digits_maybe = parse_guess_string(&guess_string.trim());
             match digits_maybe {
                 Err(msg) => { println!("{}" , msg); }
                 Ok(guess_digits) => {
-                    match calculate_score(&*given_digits, &*guess_digits) {
+                    match calculate_score(&given_digits, &guess_digits) {
                         (NUMBER_OF_DIGITS, _) => {
                             println!("you win!");
                             break ;

--- a/src/chinese_remainder.rs
+++ b/src/chinese_remainder.rs
@@ -10,7 +10,7 @@ fn chinese_remainder(l: &[(i32, i32)]) -> Option<i32> {
     let product = l.iter().fold(1, |prod, &(_, n)| prod * n);
 
     let mut sum = 0;
-    for &(a, n) in l.iter() {
+    for &(a, n) in l {
         let mut term = product / n;
 
         let inv = match mul_inv(term, n) {

--- a/src/crc_32.rs
+++ b/src/crc_32.rs
@@ -22,7 +22,7 @@ fn crc(bytes: &[u8]) -> u32 {
     }
 
     let mut crc: u32 = 0xffffffff;
-    for byte in bytes.iter() {
+    for byte in bytes {
         crc = table[(crc as u8 ^ *byte) as usize] ^ (crc >> 8);
     }
     crc ^ 0xffffffff

--- a/src/dijkstras_algorithm.rs
+++ b/src/dijkstras_algorithm.rs
@@ -105,7 +105,7 @@ impl<'a> Graph<'a> {
             match queue.pop() {
                 None     => break,
                 Some(DistPair(u, dist_u)) => {
-                    for &v in self.adj_list[u].iter() {
+                    for &v in &(self.adj_list[u]) {
                         let cost_uv = match self.costs.get(&(u, v)) {
                             Some(&x) => x,
                             None     => usize::MAX,

--- a/src/dns_query.rs
+++ b/src/dns_query.rs
@@ -20,7 +20,7 @@ fn get_ips(host: &str) -> Vec<IpAddr> {
 
 #[cfg(not(test))]
 fn main() {
-    for ip in get_ips("www.kame.net").iter() {
+    for ip in &get_ips("www.kame.net") {
         println!("{}", ip);
     }
 }

--- a/src/entropy.rs
+++ b/src/entropy.rs
@@ -44,7 +44,7 @@ fn test_entropy() {
         ("Rosetta Code", 3.084962500407)];
     // Good enough, actual float epsilon is much smaller
     let epsilon: f64 = 0.0000001;
-    for (input, expected) in tests.into_iter() {
+    for (input, expected) in tests {
         let output = shannon_entropy(input);
         assert!((output - expected).abs() < epsilon);
     }

--- a/src/factorial.rs
+++ b/src/factorial.rs
@@ -30,7 +30,7 @@ fn main () {
     let fs = vec![("Recursive", factorial_recursive as fn(usize) -> usize),
                   ("Iterative", factorial_iterative as fn(usize) -> usize),
                   ("Looooooop", factorial_loop as fn(usize) -> usize)];
-    for (name, f) in fs.into_iter() {
+    for (name, f) in fs {
         println!("---------\n{}", name);
         for i in 1us..10 {
             println!("{}", f(i))

--- a/src/fibonacci.rs
+++ b/src/fibonacci.rs
@@ -6,7 +6,7 @@ fn main() {
                    (fib_tail_recursive as fn(u64) -> u64, "tail recursive"),
                    (fib_iterative as fn(u64) -> u64, "iterative")];
 
-    for (f, desc) in fns.into_iter() {
+    for (f, desc) in fns {
         let r = (0u64..10).map(|i| f(i)).collect::<Vec<u64>>();
         println!("{} implementation:\n{:?}\n", desc, r);
     }
@@ -64,7 +64,7 @@ mod test {
         let fns = vec![fib_recursive as fn(u64) -> u64, 
             fib_tail_recursive as fn(u64) -> u64,
             fib_iterative as fn(u64) -> u64];
-        for &f in fns.iter() {
+        for &f in &fns {
             tester(f);
         }
     }

--- a/src/fibonacci_n-step_number_sequences.rs
+++ b/src/fibonacci_n-step_number_sequences.rs
@@ -24,7 +24,7 @@ impl Iterator for GenFibonacci {
 #[cfg(not(test))]
 fn print(buf: Vec<u64>, len: usize) {
     let mut sum = 0;
-    for &elt in buf.iter() { sum += elt; print!("\t{}", elt); }
+    for &elt in &buf { sum += elt; print!("\t{}", elt); }
     let iter = GenFibonacci { buf: buf, sum: sum, idx: 0 };
     for x in iter.take(len) {
         print!("\t{}", x);

--- a/src/fibonacci_word.rs
+++ b/src/fibonacci_word.rs
@@ -39,7 +39,7 @@ fn main() {
     let mut i = 1us;
 
     println!("{:>2}:{:>10} {}", "N", "length", "entropy");
-    for &(length, entropy) in words.iter() {
+    for &(length, entropy) in &words {
         println!("{:>2}:{:>10} {:.15}", i, length, entropy);
         i += 1;
     }

--- a/src/handle_a_signal.rs
+++ b/src/handle_a_signal.rs
@@ -42,7 +42,7 @@ fn main()
     // Integer counter
     let mut i = 0u32;
     // Every `duration`...
-    for _ in &periodic {
+    for _ in periodic.iter() {
         // Break if SIGINT was handled
         if unsafe { GOT_SIGINT.load(Ordering::Acquire) } { break }
         // Otherwise, increment and display the integer and continue the loop.

--- a/src/handle_a_signal.rs
+++ b/src/handle_a_signal.rs
@@ -42,7 +42,7 @@ fn main()
     // Integer counter
     let mut i = 0u32;
     // Every `duration`...
-    for _ in periodic.iter() {
+    for _ in &periodic {
         // Break if SIGINT was handled
         if unsafe { GOT_SIGINT.load(Ordering::Acquire) } { break }
         // Otherwise, increment and display the integer and continue the loop.

--- a/src/hough_transform.rs
+++ b/src/hough_transform.rs
@@ -69,7 +69,7 @@ fn save_pgm(img: &ImageGray8, filename: &str) {
 
     // Write header
 
-    match file.write_line(&* format!("P5\n{}\n{}\n255", img.width, img.height)) {
+    match file.write_line(& format!("P5\n{}\n{}\n255", img.width, img.height)) {
         Err(e) => println!("Failed to write header: {}", e),
         _ => {},
     }

--- a/src/huffman_coding.rs
+++ b/src/huffman_coding.rs
@@ -103,9 +103,9 @@ fn build_encoding_table(tree: &HNode,
                       start_str: &str) {
     match tree.item {
         HItem::Tree(ref data) => {
-            build_encoding_table(&*data.left, table,
+            build_encoding_table(&data.left, table,
                                &format!("{}0", start_str)[]);
-            build_encoding_table(&*data.right, table,
+            build_encoding_table(&data.right, table,
                                &format!("{}1", start_str)[]);
         },
         HItem::Leaf(ch)   => {table.insert(ch, start_str.to_string());}

--- a/src/iban.rs
+++ b/src/iban.rs
@@ -52,7 +52,7 @@ fn parse_digits(chars: &[char]) -> Option<BigInt> {
     let mut vec: Vec<u8> = Vec::with_capacity(chars.len() + 10);
 
     // Copy the digits to the vector and expand the letters to digits
-    for &c in chars.iter() {
+    for &c in chars {
         match c.to_digit(36) {
             Some(d)	=> vec.extend(d.to_string().bytes()),
             None    => return None

--- a/src/iban.rs
+++ b/src/iban.rs
@@ -38,7 +38,7 @@ fn is_valid(iban: &str) -> bool {
     }
 
     // Expand letters to digits
-    let iban_int = parse_digits(&*iban_chars);
+    let iban_int = parse_digits(&iban_chars);
 
     // Check if the remainder is one
     match iban_int {

--- a/src/isaac.rs
+++ b/src/isaac.rs
@@ -16,7 +16,7 @@ fn main () {
     println!("msg: {}", MSG);
     println!("key: {}", KEY);
     print!("XOR: ");
-    for a in encr.iter() {
+    for a in &encr {
         print!("{:02X}", *a);
     }
 

--- a/src/json.rs
+++ b/src/json.rs
@@ -13,7 +13,7 @@ fn main() {
     // Encode contact to json
     let c = Contact { name: "John".to_string(), city: "Paris".to_string() };
     let json = json::encode(&c);
-    println!("Encoded: {:?}", &*(json.unwrap()));
+    println!("Encoded: {:?}", &(json.unwrap()));
 
     // Decode json to contact
     let json_str = "{\"name\":\"Alan\", \"city\":\"Tokyo\"}";
@@ -24,7 +24,7 @@ fn main() {
 #[test]
 fn test_coherence() {
     let c = Contact { name: "John".to_string(), city: "Paris".to_string() };
-    assert!(json::decode::<Contact>(&*(json::encode(&c)).unwrap()) == Ok(c));
+    assert!(json::decode::<Contact>(&(json::encode(&c)).unwrap()) == Ok(c));
 }
 
 #[test]

--- a/src/k-d-tree.rs
+++ b/src/k-d-tree.rs
@@ -207,7 +207,7 @@ pub fn main() {
 
     let start_search_time = get_time();
     let mut total_n_visited = 0us;
-    for target in random_targets.iter() {
+    for target in &random_targets {
         let (_, n_visited) = random_tree.find_nearest_neighbor(target);
         total_n_visited += n_visited;
     }

--- a/src/kahansum.rs
+++ b/src/kahansum.rs
@@ -21,7 +21,7 @@ fn with_bits(val: f32, digits: usize) -> f32 {
 fn kahan_sum(lst: &[f32]) -> Option<f32> {
     let mut sum = 0.0f32;
     let mut c = 0.0f32;
-    for i in lst.iter() {
+    for i in lst {
         let y = *i - c;
         let t = sum + y;
         c = (t - sum) - y;
@@ -39,7 +39,7 @@ fn all_sums(vec: &[f32]) -> Vec<f32> {
         match v {
             Some(_v) =>  {
                 let mut sum = 0.0f32;
-                for e in _v.iter() {
+                for e in &_v {
                     sum += with_bits(*e, 1);
                 }
                 res.push(with_bits(sum, 1));

--- a/src/leap_year.rs
+++ b/src/leap_year.rs
@@ -7,7 +7,7 @@ fn is_leap_year(year: i32) -> bool {
 
 #[cfg(not(test))]
 fn main () {
-    for &year in [1900, 1995, 1996, 1999, 2000, 2001].iter() {
+    for &year in &[1900, 1995, 1996, 1999, 2000, 2001] {
         println!("{} {} a leap year", year,
                  if is_leap_year(year) { "is" } else { "is not" });
     }

--- a/src/levenshtein_distance_alignment.rs
+++ b/src/levenshtein_distance_alignment.rs
@@ -97,7 +97,7 @@ fn test_lev_distance() {
         vec![( "sunday" , "saturday" , (3, "s--unday", "sunurday"))  , 
             ( "sitting" , "kitten" , (3, "sitting", "kitten-")) , 
             ("test" , "test" , (0, "test", "test") )];
-    for (word1, word2, dist) in test_results.into_iter() {
+    for (word1, word2, dist) in test_results {
         let (d, s1, s2) = levenshtein_distance ( word1 , word2 ); 
         assert_eq!( (d, &s1[], &s2[]) , dist);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ mod test {
         let regex = regex!("path = \"(.*)\"");
         reader.lines().filter_map(|l| {
             let l = l.unwrap();
-            regex.captures(&*l).map(|c| c.at(1).map(|s| Path::new(s))
+            regex.captures(&l).map(|c| c.at(1).map(|s| Path::new(s))
                                                .unwrap()
                                                .filename_str()
                                                .unwrap()

--- a/src/linear_congruential_generator.rs
+++ b/src/linear_congruential_generator.rs
@@ -72,7 +72,7 @@ mod test {
     fn bsd() {
         let values = [12345u32, 1406932606, 654583775, 1449466924, 229283573, 1109335178, 1051550459, 1293799192, 794471793, 551188310];
         let mut lcg = BSDLinearCongruentialGenerator::new(0);
-        for val in values.iter() {
+        for val in &values {
             assert_eq!(lcg.next(), *val);
         }
     }

--- a/src/luhn_test.rs
+++ b/src/luhn_test.rs
@@ -38,7 +38,7 @@ fn luhn_test(n: u64) -> bool {
 #[cfg(not(test))]
 fn main() {
     let nos = [49927398716, 49927398717, 1234567812345678, 1234567812345670];
-    for n in nos.iter() {
+    for n in &nos {
         if luhn_test(*n) {
             println!("{} passes." , n);
         } else { println!("{} fails." , n); }

--- a/src/lzw.rs
+++ b/src/lzw.rs
@@ -16,7 +16,7 @@ fn compress(original_str: &str) -> Vec<i32> {
 
    let mut result = vec![];
    let mut w = vec![];
-   for &c in original.iter() {
+   for &c in original {
       let mut wc = w.clone();
       wc.push(c);
 
@@ -50,7 +50,7 @@ fn decompress(compressed: &[i32]) -> String {
    let mut w = vec![compressed[0].clone() as u8];
    let compressed = &compressed[1..];
    let mut result = w.clone();
-   for &k in compressed.iter() {
+   for &k in compressed {
       let entry = match dictionary.get(&k) {
           Some(v) => v.clone(),
           None if k == dict_size => { let mut new = w.clone(); new.push(w[0].clone()); new }

--- a/src/markov_algorithm.rs
+++ b/src/markov_algorithm.rs
@@ -234,7 +234,7 @@ fn main() {
 
 #[test]
 fn test_samples() {
-    for sample in get_samples().iter() {
+    for sample in &get_samples() {
         match MarkovAlgorithm::from_str(sample.ruleset) {
             Ok(algorithm) => assert_eq!(sample.expected_result,
                                         algorithm.apply(sample.input)),

--- a/src/md5-implementation.rs
+++ b/src/md5-implementation.rs
@@ -19,7 +19,7 @@ fn main() {
     b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
     b"12345678901234567890123456789012345678901234567890123456789012345678901234567890"];
 
-    for &input in inputs.iter() {
+    for &input in &inputs {
         println!("{:?}", md5(input));
     }
 }
@@ -54,7 +54,7 @@ struct MD5([u8; 16]);
 impl Debug for MD5 {
     fn fmt(&self, f: &mut Formatter) -> Result {
         let MD5(md5)=*self;
-        for b in md5.iter() {
+        for b in &md5 {
             try!(write!(f, "{:02x}", *b));
         }
         Ok(())
@@ -186,7 +186,7 @@ fn known_hashes() {
     (b"12345678901234567890123456789012345678901234567890123456789012345678901234567890",
         "57edf4a22be3c955ac49da2e2107b67a")];
 
-    for &(i,o) in in_out.iter() {
+    for &(i,o) in &in_out {
         let m=md5(i);
         assert_eq!(format!("{:?}", m), o.to_string());
     }

--- a/src/modular_exponentiation.rs
+++ b/src/modular_exponentiation.rs
@@ -45,7 +45,7 @@ fn test_mod_exp() {
         (18, 112994442, 1000000001, 59108659),
     ];
 
-    for &(a, b, m, expected) in tests.iter() {
+    for &(a, b, m, expected) in &tests {
         let a = a.to_biguint().unwrap();
         let b = b.to_biguint().unwrap();
         let m = m.to_biguint().unwrap();

--- a/src/palindrome.rs
+++ b/src/palindrome.rs
@@ -21,7 +21,7 @@ fn palindrome(string: &str) -> bool {
 #[cfg(not(test))]
 fn main() {
     let test_strings = ["nope", "eevee", "lalala", "rust", "lalalal"];
-    for &string in test_strings.iter() {
+    for &string in &test_strings {
         println!("{}: {}", string, palindrome(string));
     }
 }

--- a/src/pangram.rs
+++ b/src/pangram.rs
@@ -17,7 +17,7 @@ fn is_pangram(sentence: &str) -> bool {
 fn main() {
     let test_sentences = ["The quick brown fox jumps over the lazy dog.",
                           "The quick brown frog jumps over the lazy dog."];
-    for &sentence in test_sentences.iter() {
+    for &sentence in &test_sentences {
         println!("\"{}\" {} a pangram", sentence,
                  if is_pangram(sentence) { "is" } else { "is not" });
     }

--- a/src/parallel_calculations.rs
+++ b/src/parallel_calculations.rs
@@ -30,7 +30,7 @@ fn largest_min_factor_chan(numbers: &[usize]) -> usize {
     let (sender, receiver) = channel();
 
     // Send all the minimal factors
-    for &x in numbers.iter() {
+    for &x in numbers {
         let child_sender = sender.clone();
         Thread::spawn(move || { child_sender.send(min_factor(x)).unwrap() });
     }

--- a/src/permutations_with_repetitions.rs
+++ b/src/permutations_with_repetitions.rs
@@ -59,7 +59,7 @@ impl<'a, T> Iterator for PermutationIterator<'a, T> where T: Clone {
 fn main() {
     let universe = ["Annie", "Barbie"];
     for p in permutations(&universe[], 3) {
-        for element in p.iter() {
+        for element in &p {
             print!("{} ", element);
         }
         println!("");

--- a/src/reverse_words_str.rs
+++ b/src/reverse_words_str.rs
@@ -36,7 +36,7 @@ fn test_rev_words() {
                  ("cat     dog", "dog cat"),
                  ("cat dog frog", "frog dog cat")];
 
-    for &(input, expected) in tests.iter() {
+    for &(input, expected) in &tests {
         let output = rev_words(input);
         assert_eq!(expected, output);
     }
@@ -59,7 +59,7 @@ fn test_rev_words_on_lines() {
                  ("a b\nb a", "b a\na b"),
                  ("a b\nc d\ne f", "b a\nd c\nf e")];
 
-    for &(input, expected) in tests.iter() {
+    for &(input, expected) in &tests {
         let output = rev_words_on_lines(input);
         assert_eq!(expected, output);
     }

--- a/src/roots_of_unity.rs
+++ b/src/roots_of_unity.rs
@@ -9,7 +9,7 @@ use std::f32::consts;
 fn main() {
     let degree = 3us;
 
-    for root in roots_of_unity(degree).iter() {
+    for root in &roots_of_unity(degree) {
         println!("{}", root);
     }
 }

--- a/src/s_expressions.rs
+++ b/src/s_expressions.rs
@@ -271,14 +271,14 @@ impl<'a> SExp<'a> {
                     Some(mut l) => {
                         // We allocate a slot for the current list in our parse context (needed for
                         // safety) before pushing it onto its parent list.
-                        l.push(List(&**arena.alloc(list)));
+                        l.push(List(&*arena.alloc(list)));
                         // Now reset the current list to the parent list
                         list = l;
                     },
                     // There was nothing on the stack, so we're at the end of the topmost list.
                     // The check to make sure there are no more tokens is required for correctness.
                     None => return match try!(tokens.next()) {
-                        EOF => Ok(List(&**arena.alloc(list))),
+                        EOF => Ok(List(&*arena.alloc(list))),
                         _ => Err(ExpectedEOF),
                     }
                 },

--- a/src/self-describing_numbers.rs
+++ b/src/self-describing_numbers.rs
@@ -55,7 +55,7 @@ fn test_is_self_describing() {
         (6210001000, true),
     ];
 
-    for &(n, expected) in tests.iter() {
+    for &(n, expected) in &tests {
         assert_eq!(is_self_describing(n), expected);
     }
 }

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -20,7 +20,7 @@ fn main() {
     d.write_all(b"The quick brown fox jumps over the lazy dog").unwrap();
     let sha1=d.sha1();
 
-    for h in sha1.iter() {
+    for h in &sha1 {
         print!("{:x} ", *h);
     }
  }
@@ -212,7 +212,7 @@ fn known_sha1s() {
             ,0x10 ,0x0d ,0xb4,0xb3]
          )];
 
-    for &(i, o) in input_output.iter() {
+    for &(i, o) in &input_output {
         let mut d = Digest::new();
         d.write_str(i).unwrap();
         let sha1=d.sha1();

--- a/src/short_circuit_evaluation.rs
+++ b/src/short_circuit_evaluation.rs
@@ -13,8 +13,8 @@ fn b(x: bool) -> bool {
 fn main() {
     let booleans = [true, false];
 
-    for &i in booleans.iter() {
-        for &j in booleans.iter() {
+    for &i in &booleans {
+        for &j in &booleans {
             println!("{} and {} is {}", i, j, a(i) && b(j));
             println!("{} or {} is {}", i, j, a(i) || b(j));
         }

--- a/src/strip_comments_from_a_string.rs
+++ b/src/strip_comments_from_a_string.rs
@@ -12,7 +12,7 @@ fn test_strip_comments() {
                   "  apples, pears "];
     let output = "apples, pears";
 
-    for &input in inputs.iter() {
+    for &input in &inputs {
         assert_eq!(strip_comments(input), output)
     }
 }
@@ -23,7 +23,7 @@ fn main() {
                   "apples, pears ; and bananas",
                   "  apples, pears "];
 
-    for &input in inputs.iter() {
+    for &input in &inputs {
         println!("Input: {}\nStripped: {}", input, strip_comments(input))
     }
 }

--- a/src/sudoku.rs
+++ b/src/sudoku.rs
@@ -220,7 +220,7 @@ fn main() {
 
     println!("{}", puzzle);
 
-    for answer in solve_sudoku(puzzle).iter() {
+    for answer in &solve_sudoku(puzzle) {
         println!("{}", answer);
     }
 }

--- a/src/taxicab_numbers.rs
+++ b/src/taxicab_numbers.rs
@@ -87,7 +87,7 @@ fn main() {
     for (at, ways) in numbers.take(2006).enumerate()
                              .filter(|&(at, _)| at + 1 <= 25 || at + 1 >= 2000) {
         print!("{:>4}:{:>10}", at + 1, ways[0].value);
-        for &SumCubes{ a, b, .. } in ways.iter() {
+        for &SumCubes{ a, b, .. } in &ways {
             print!(" = {:>4}^3 + {:>4}^3", a, b);
         }
         print!("\n");
@@ -105,7 +105,7 @@ fn test_taxicab_numbers() {
 
     for (&expected, ways) in seq.iter().zip(TaxicabNumbers::new()) {
         assert!(ways.len() > 1);
-        for &SumCubes{value, ..} in ways.iter() {
+        for &SumCubes{value, ..} in &ways {
             assert_eq!(value, expected);
         }
     }

--- a/src/walk_recursive.rs
+++ b/src/walk_recursive.rs
@@ -16,7 +16,7 @@ fn walk(path: &Path, regex: &Regex) {
         Err(_) => return
     };
 
-    for subpath in result.iter() {
+    for subpath in &result {
         match subpath.filename_str() {
             Some(filename) => {
                 if regex.is_match(filename) {

--- a/src/webserver.rs
+++ b/src/webserver.rs
@@ -68,7 +68,7 @@ fn main() {
 
     let host = "127.0.0.1";
     let port = if args.len() == 2 {
-        args[1].parse::<u16>().ok().expect(&*format!("Usage: {} <port>", args[0]))
+        args[1].parse::<u16>().ok().expect(&format!("Usage: {} <port>", args[0]))
     } else {
         80
     };

--- a/src/write_ppm.rs
+++ b/src/write_ppm.rs
@@ -19,8 +19,8 @@ impl PPMWritable for Image {
         let mut writer = BufferedWriter::new(file);
         try!(writer.write_line("P6"));
         try!(write!(&mut writer, "{} {} {}\n", self.width, self.height, 255us));
-        for color in self.data.iter() {
-            for channel in [color.red, color.green, color.blue].iter() {
+        for color in &(self.data) {
+            for channel in &[color.red, color.green, color.blue] {
                 try!(writer.write_u8(*channel));
             }
         }


### PR DESCRIPTION
-  for loops now act on IntoIterator, so iter() can be left out in for loops in many cases
-  deref coercions have landed. Removed a few &*

see http://this-week-in-rust.org/blog/2015/02/02/this-week-in-rust-68/ for details