### PR TITLE
rustup20150206

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -38,7 +38,7 @@ name = "rand"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -66,6 +66,6 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,11 +2,12 @@
 name = "rust-rosetta"
 version = "0.0.1"
 dependencies = [
- "num 0.1.12 (git+https://github.com/rust-lang/num)",
- "regex 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex_macros 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -20,16 +21,30 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "log"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "num"
 version = "0.1.12"
-source = "git+https://github.com/rust-lang/num#0811c72bacce6d8adc7a25be8292ba55f4118d9e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rustc-serialize 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -37,17 +52,17 @@ name = "regex_macros"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "regex 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-serialize"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "time"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ regex = "*"
 regex_macros = "*"
 time = "*"
 rustc-serialize = "*"
+rand = "*"
 
 [lib]
 # used by compile_time_calculation.rs

--- a/src/100_doors.rs
+++ b/src/100_doors.rs
@@ -7,7 +7,7 @@ use std::num::Float;
 use std::iter::Map;
 use std::ops::Range;
 
-type DoorIter = Map<u32, DoorState, Range<u32>, fn(u32) -> DoorState>;
+type DoorIter = Map<Range<u32>, fn(u32) -> DoorState>;
 
 #[derive(Debug, PartialEq)]
 enum DoorState { Open, Closed, }

--- a/src/24_game.rs
+++ b/src/24_game.rs
@@ -16,14 +16,15 @@
 #![feature(unicode)]
 #![feature(collections)]
 #![feature(io)]
-#![feature(rand)]
+
+extern crate rand;
 
 use std::cmp::Ordering::{self, Greater};
 use std::char::CharExt;
 
 #[cfg(not(test))]
 fn main() {
-    use std::{rand, old_io};
+    use std::old_io;
 
     let mut rng = rand::thread_rng();
     let mut input = old_io::stdin();
@@ -358,7 +359,7 @@ mod test {
     #[test]
     fn lexer_iter() {
         // test read token and character's offset in the iterator
-        let t = |&: lex: &mut Lexer, exp_tok: Token, exp_pos: usize| {
+        let t = |lex: &mut Lexer, exp_tok: Token, exp_pos: usize| {
             assert_eq!(lex.next(), Some(exp_tok));
             assert_eq!(lex.offset, exp_pos);
         };

--- a/src/24_game_rpn.rs
+++ b/src/24_game_rpn.rs
@@ -1,13 +1,14 @@
 // Implements http://rosettacode.org/wiki/24_game
 // Uses RPN expression
 #![allow(unused_features)] // feature(rand) is used only in main
-#![feature(rand)]
+
 #![feature(io)]
 #![feature(core)]
+extern crate rand;
 
 #[cfg(not(test))]
 fn main() {
-    use std::rand::{thread_rng, Rng};
+    use rand::{thread_rng, Rng};
     use std::old_io;
 
     let mut rng = thread_rng();

--- a/src/9_billion_names_of_God_the_integer.rs
+++ b/src/9_billion_names_of_God_the_integer.rs
@@ -76,7 +76,7 @@ mod test {
     #[test]
     fn test_cumulative() {
         let mut solver = Solver::new();
-        let mut t = |&mut: n: usize, expected: &str| {
+        let mut t = |n: usize, expected: &str| {
             assert_eq!(solver.row_sum(n), &expected.parse::<BigUint>().unwrap());
         };
 
@@ -89,7 +89,7 @@ mod test {
     #[test]
     fn test_row() {
         let mut solver = Solver::new();
-        let mut t = |&mut: n: usize, expected: &str| {
+        let mut t = |n: usize, expected: &str| {
             assert_eq!(solver.row_string(n), expected);
         };
 

--- a/src/accumulator_factory.rs
+++ b/src/accumulator_factory.rs
@@ -3,7 +3,7 @@ use std::ops::Add;
 pub fn accum<'a, T>(mut n: T) -> Box<FnMut(T) -> T + 'a> 
     where T: 'a + Add<T, Output=T> + Copy
 {
-    Box::new(move |&mut: i: T| { n = n + i; n })
+    Box::new(move |i: T| { n = n + i; n })
 }
 
 #[cfg(not(test))]

--- a/src/active_object.rs
+++ b/src/active_object.rs
@@ -70,7 +70,7 @@ impl<S: Mul<f64, Output=T> + Float,
             let periodic = timer.periodic(frequency);
             let frequency_ms = frequency.num_milliseconds();
             let mut t = 0;
-            let mut k: Box<Fn(i64) -> S + Send> = Box::new(|&: _| Float::zero());
+            let mut k: Box<Fn(i64) -> S + Send> = Box::new(|_| Float::zero());
             let mut k_0: S = Float::zero();
             loop {
                 // Here's the selection we talked about above.  Note that we are careful to call
@@ -137,7 +137,7 @@ impl<S: Mul<f64, Output=T> + Float,
 fn integrate() -> f64 {
     let object = Integrator::new(Duration::milliseconds(10));
     let mut timer = Timer::new().unwrap();
-    object.input(Box::new(|&: t: i64| {
+    object.input(Box::new(|t: i64| {
         let f = 1. / Duration::seconds(2).num_milliseconds() as f64;
         (2. * PI * f * t as f64).sin()
     })).ok().expect("Failed to set input");
@@ -160,12 +160,12 @@ fn solution() {
     // FIXME(pythonesque): When unboxed closures are fixed, fix integrate() to take two arguments.
     let object = Integrator::new(Duration::milliseconds(10));
     let mut timer = Timer::new().unwrap();
-    object.input(Box::new(|&: t: i64| {
+    object.input(Box::new(|t: i64| {
         let f = 1. / (Duration::seconds(2) / 10).num_milliseconds() as f64;
         (2. * PI * f * t as f64).sin()
     })).ok().expect("Failed to set input");
     timer.sleep(Duration::seconds(2) / 10);
-    object.input(Box::new(|&: _| 0.)).ok().expect("Failed to set input");
+    object.input(Box::new(|_| 0.)).ok().expect("Failed to set input");
     timer.sleep(Duration::seconds(1) / 10);
     assert_eq!(object.output() as i64, 0)
 }

--- a/src/agm.rs
+++ b/src/agm.rs
@@ -3,21 +3,19 @@
 // cargo run --name agm arg1 arg2
 
 #![allow(unused_features)] // feature(os) is used only in main
-
 #![feature(std_misc)]
+#![feature(env)]
 #![feature(os)]
-
 #![feature(collections)]
 
 use std::num::Float;
 
 #[cfg(not(test))]
 fn main () {
-    let args = std::os::args();
-    let args = &args[];
+    let mut args = std::env::args();
 
-    let x = args[1].parse::<f32>().unwrap();
-    let y = args[2].parse::<f32>().unwrap();
+    let x = args.next().unwrap().into_string().unwrap().parse::<f32>().unwrap();
+    let y = args.next().unwrap().into_string().unwrap().parse::<f32>().unwrap();
 
     let result = agm(x,y);
     println!("The arithmetic-geometric mean is {}", result);

--- a/src/atomic_updates.rs
+++ b/src/atomic_updates.rs
@@ -9,14 +9,15 @@
 // (previously I tried, in order, std::sync::RwLock, std::sync::Mutex, and std::sync::Semaphore)
 // and this type still appears to have quite a bit of overhead.
 #![feature(core)]
-#![feature(rand)]
+
 #![feature(io)]
 #![feature(std_misc)] 
+extern crate rand;
 
 use std::old_io::timer::Timer;
 use std::iter::AdditiveIterator;
-use std::rand::{Rng, weak_rng};
-use std::rand::distributions::{IndependentSample, Range};
+use rand::{Rng, weak_rng};
+use rand::distributions::{IndependentSample, Range};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::duration::Duration;

--- a/src/balanced_brackets.rs
+++ b/src/balanced_brackets.rs
@@ -1,7 +1,8 @@
 // Implements http://rosettacode.org/wiki/Balanced_brackets
 #![allow(unused_features)] // feature(rand) is used only in main
-#![feature(rand)]
+
 #![feature(core)]
+extern crate rand;
 
 trait Balanced {
     /// Returns true if the brackets are balanced
@@ -31,7 +32,7 @@ impl<'a> Balanced for str {
 #[cfg(not(test))]
 
 fn generate_brackets(num: usize) -> String {
-    use std::rand::random;
+    use rand::random;
 
     (0..num).map(|_| if random() { '[' } else { ']' }).collect()
 }

--- a/src/bitmap.rs
+++ b/src/bitmap.rs
@@ -59,8 +59,6 @@ impl Index<(usize, usize)> for Image {
 }
 
 impl IndexMut<(usize, usize)> for Image {
-    type Output=Color;
-
     fn index_mut<'a>(&'a mut self, &(x, y): &(usize, usize)) -> &'a mut Color {
         & mut self.data[x + y*self.width]
     }

--- a/src/bulls_and_cows.rs
+++ b/src/bulls_and_cows.rs
@@ -1,11 +1,12 @@
 // http://rosettacode.org/wiki/Bulls_and_cows
 #![allow(unused_features)] // feature(io) is not used in test
 
-#![feature(rand)]
+
 #![feature(core)]
 #![feature(unicode)]
 #![feature(io)]
- 
+extern crate rand;
+
 use std::fmt::{self, Display};
 use std::char::CharExt;
 
@@ -13,7 +14,7 @@ const NUMBER_OF_DIGITS: usize = 4;
 
 /// generates a random NUMBER_OF_DIGITS
 fn generate_digits() -> Vec<usize> {
-    use std::rand;
+    use rand;
 
     let mut rng = rand::thread_rng();
     rand::sample(&mut rng, (1us..10), 4)

--- a/src/closures-value_capture.rs
+++ b/src/closures-value_capture.rs
@@ -11,7 +11,7 @@ fn closure_gen<'a>(x: u32) -> Box<Fn() -> f64 + 'a> {
 }
 
 // type alias for the closure iterator
-type ClosureIter<'a> = Map<u32, Box<Fn() -> f64 + 'a>, Counter<u32>, fn(u32) -> Box<Fn() -> f64 + 'a>>;
+type ClosureIter<'a> = Map<Counter<u32>, fn(u32) -> Box<Fn() -> f64 + 'a>>;
 
 // return an iterator that on every iteration returns
 // a closure computing the index of the iteration squared

--- a/src/concurrent_computing.rs
+++ b/src/concurrent_computing.rs
@@ -1,11 +1,11 @@
 // Implements http://rosettacode.org/wiki/Concurrent_computing
-#![feature(rand)]
+
 #![feature(std_misc)]
 #![feature(io)]
 #![feature(core)]
-
+extern crate rand;
 use std::old_io::timer::sleep;
-use std::rand::random;
+use rand::random;
 use std::time::duration::Duration;
 use std::thread::Thread;
 

--- a/src/dijkstras_algorithm.rs
+++ b/src/dijkstras_algorithm.rs
@@ -1,5 +1,4 @@
 // Implements http://rosettacode.org/wiki/Dijkstra's_algorithm
-#![feature(std_misc)]
 #![feature(core)]
 
 use std::collections::{HashMap, BinaryHeap, DList};

--- a/src/entropy.rs
+++ b/src/entropy.rs
@@ -1,5 +1,4 @@
 // Implements http://rosettacode.org/wiki/Entropy
-#![feature(std_misc)]
 #![feature(core)]
 use std::num::Float;
 use std::collections::HashMap;

--- a/src/function_composition.rs
+++ b/src/function_composition.rs
@@ -7,8 +7,8 @@ fn main() {
     use std::f32::consts;
 
     // the two functions we will compose:
-    let f = |&: x: u32| x.to_string();
-    let g = |&: x: f32| x as u32;
+    let f = |x: u32| x.to_string();
+    let g = |x: f32| x as u32;
 
     // their composition
     let comp = compose(f, g);
@@ -19,7 +19,7 @@ fn main() {
 fn compose<'a, F, G, A, B, C>(f: F, g: G) -> Box<Fn(A) -> C + 'a>
     where G: Fn(A) -> B + 'a, F: Fn(B) -> C + 'a
 {
-    Box::new( move |&: a: A| f(g(a)) )
+    Box::new( move |a: A| f(g(a)) )
 }
 
 #[test]

--- a/src/guess_number.rs
+++ b/src/guess_number.rs
@@ -1,8 +1,8 @@
 // Implements http://rosettacode.org/wiki/Guess_the_number
-#![feature(rand)]
-#![feature(io)]
 
-use std::rand::{thread_rng, Rng};
+#![feature(io)]
+extern crate rand;
+use rand::{thread_rng, Rng};
 use std::old_io::stdio::stdin;
 
 fn main() {

--- a/src/harshad_or_niven_series.rs
+++ b/src/harshad_or_niven_series.rs
@@ -4,7 +4,7 @@
 
 use std::usize;
 fn main() {
-    let digit_sum = |&: i: usize| i.to_string().chars()
+    let digit_sum = |i: usize| i.to_string().chars()
         .fold(0us, |d, c| d + c.to_digit(10).unwrap());
     let mut harshads = (1us..usize::MAX).filter(|&n| n % digit_sum(n) == 0);
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -4,7 +4,7 @@
 #![feature(io)]
 #![feature(core)]
 #![feature(os)]
-#![feature(std_misc)]
+#![feature(env)]
 
 use std::old_io::net::tcp::TcpStream;
 use std::old_io::IoResult;
@@ -30,7 +30,8 @@ fn get_index(target: &str, port: u16) -> IoResult<String> {
 fn main() {
     const PORT: u16 = 80;
 
-    let target = std::os::args().pop().unwrap();
+    let target = std::env::args().next().unwrap()
+        .into_string().unwrap();
     println!("Making the request... This might take a minute.");
     match get_index(&target[], PORT) {
         Ok(out) => println!("{}", out),

--- a/src/http.rs
+++ b/src/http.rs
@@ -5,6 +5,7 @@
 #![feature(core)]
 #![feature(os)]
 #![feature(env)]
+#![feature(std_misc)]
 
 use std::old_io::net::tcp::TcpStream;
 use std::old_io::IoResult;

--- a/src/huffman_coding.rs
+++ b/src/huffman_coding.rs
@@ -1,6 +1,6 @@
+
 // Implement data structures for a Huffman encoding tree:
 //   http://rosettacode.org/wiki/Huffman_coding
-#![feature(std_misc)]
 #![feature(core)]
 
 use std::collections::HashMap;

--- a/src/k-d-tree.rs
+++ b/src/k-d-tree.rs
@@ -1,11 +1,12 @@
 // Implements http://rosettacode.org/wiki/K-d_tree
 #![feature(core)]
-#![feature(rand)]
+
 
 extern crate time;
+extern crate rand;
 
 use std::num::Float;
-use std::rand::Rng;
+use rand::Rng;
 use std::cmp::Ordering;
 #[cfg(not(test))]
 use time::get_time;
@@ -58,7 +59,7 @@ impl KDTreeNode {
     
         // Split around the median
         let pivot = quickselect_by(points, points_len/2,
-            &|&: a, b| a.coords[dim].partial_cmp(&b.coords[dim]).unwrap());
+            &|a, b| a.coords[dim].partial_cmp(&b.coords[dim]).unwrap());
 
         let left = Some(Box::new(KDTreeNode::new(&mut points[0us..points_len/2],
                 (dim + 1) % pivot.coords.len())));
@@ -178,7 +179,7 @@ pub fn main() {
     let n_random = 1000us;
     let make_random_point = |&:| Point {
         coords: (0us..3).map(
-				|_| (std::rand::thread_rng().gen::<f32>()-0.5f32)*1000f32
+				|_| (rand::thread_rng().gen::<f32>()-0.5f32)*1000f32
 			).collect()
     };
     let mut random_points: Vec<Point> = (0..n_random)
@@ -222,10 +223,10 @@ pub fn main() {
 fn quickselect_by<T>(arr: &mut [T], position: usize, cmp: &Fn(&T, &T) -> Ordering) -> T 
     where T: Clone
 {
-    let mut pivot_index = std::rand::thread_rng().gen_range(0, arr.len());
+    let mut pivot_index = rand::thread_rng().gen_range(0, arr.len());
     // Need to wrap in another closure or we get ownership complaints.
     // Tried using an unboxed closure to get around this but couldn't get it to work.
-    pivot_index = partition_by(arr, pivot_index, &|&: a: &T, b: &T| cmp(a, b));
+    pivot_index = partition_by(arr, pivot_index, &|a: &T, b: &T| cmp(a, b));
     let array_len = arr.len();
     if position == pivot_index {
         arr[position].clone()

--- a/src/luhn_test.rs
+++ b/src/luhn_test.rs
@@ -5,7 +5,7 @@ use std::iter::Unfold;
 #[derive(Copy)]
 enum LuhnState { Even, Odd, }
 
-type Digits = Unfold<u64, u64, fn(&mut u64) -> Option<u64>>;
+type Digits = Unfold<u64, fn(&mut u64) -> Option<u64>>;
 
 fn digits(n: u64) -> Digits {
     fn state(s: &mut u64) -> Option<u64> {

--- a/src/pernicious_numbers.rs
+++ b/src/pernicious_numbers.rs
@@ -16,7 +16,7 @@ fn main() {
     }
 }
 
-fn pernicious() -> Filter<u64, Counter<u64>, fn(&u64) -> bool> {
+fn pernicious() -> Filter<Counter<u64>, fn(&u64) -> bool> {
     count(0u64, 1).filter(is_pernicious as fn(&u64) -> bool)
 }
 

--- a/src/population_count.rs
+++ b/src/population_count.rs
@@ -20,7 +20,7 @@ fn main() {
     print_30(odious());
 }
 
-type EvilOdiousIter = Filter<usize, Counter<usize>, fn(&usize) -> bool>;
+type EvilOdiousIter = Filter<Counter<usize>, fn(&usize) -> bool>;
 
 fn even_ones(i: &usize) -> bool { i.count_ones() % 2 == 0 }
 
@@ -33,7 +33,7 @@ fn evil() -> EvilOdiousIter {
     count(0us, 1).filter(even_ones as fn(&usize) -> bool)
 }
 
-fn pow_3() -> Map<usize, usize, Counter<usize>, fn(usize) -> usize> {
+fn pow_3() -> Map<Counter<usize>, fn(usize) -> usize> {
     fn pw(n: usize) -> usize { 3u32.pow(n).count_ones() }
 
     count(0us, 1).map(pw as fn(usize) -> usize)

--- a/src/quick_sort.rs
+++ b/src/quick_sort.rs
@@ -1,11 +1,10 @@
 //Implements http://rosettacode.org/wiki/Sorting_algorithms/Quicksort
-
 // Used by the tests
 #![allow(unused_features)]
-#![feature(rand)]
 #![feature(core)]
+extern crate rand;
 #[cfg(test)]
-use std::rand::{thread_rng, Rng};
+use rand::{thread_rng, Rng};
 
 // We use in place quick sort
 // For details see http://en.wikipedia.org/wiki/Quicksort#In-place_version

--- a/src/read_file_line.rs
+++ b/src/read_file_line.rs
@@ -3,14 +3,19 @@
 #![feature(path)]
 #![feature(os)]
 #![feature(core)]
+#![feature(env)]
+
 use std::old_io::fs::File;
 use std::old_io::BufferedReader;
-use std::os::args;
+use std::env::args;
 
 fn main() {
-    let filename = match args().len() {
-        1 => panic!("You must enter a filename to read line by line"),
-        _ => args()[1].clone()
+    let filename = {
+        if let Some(o_s) = args().nth(1) {
+            o_s.into_string().unwrap()
+        } else {
+            panic!("You must enter a filename to read line by line")
+        }
     };
 
     let file = File::open(&Path::new(&filename[]));

--- a/src/read_file_specific_line.rs
+++ b/src/read_file_specific_line.rs
@@ -2,19 +2,32 @@
 #![feature(io)]
 #![feature(path)]
 #![feature(os)]
+#![feature(env)]
 
 use std::old_io::fs::File;
 use std::old_io::BufferedReader;
-use std::os::args;
+use std::env::args;
 
 fn main() {
-    match args().len() {
-        2 => panic!("You must enter a filename to read line by line, and a line number"),
-        1 => panic!("You must enter a line number"),
-        _ => {}
-    }
-    let filename = args()[1].clone();
-    let line_number = args()[2].parse::<usize>().ok().expect("You must enter an integer as the line number");
+    let mut args =  args();
+
+    let filename = {
+        if let Some(o_s) = args.nth(1) {
+            o_s.into_string().unwrap()
+        } else {
+            panic!("You must enter a filename to read line by line")
+        }
+    };
+
+    let line_number = {
+        if let Some(o_s) = args.next() {
+            o_s.into_string().unwrap()
+                .parse::<usize>().ok()
+                .expect("You must enter an integer as the line number")
+        } else {
+            panic!("You must enter a filename to read line by line")
+        }
+    };
 
     let file = File::open(&Path::new(&filename[]));
     let mut reader = BufferedReader::new(file);

--- a/src/s_expressions.rs
+++ b/src/s_expressions.rs
@@ -142,7 +142,7 @@ impl<'a> Tokens<'a> {
                     // Unlike the quoted case, it's not an error to encounter EOF before whitespace.
                     let mut end_ch = None;
                     let str = {
-                        let mut iter = self.string.splitn(1, |&mut: ch: char| {
+                        let mut iter = self.string.splitn(1, |ch: char| {
                             let term = ch == ')' || ch == '(';
                             if term { end_ch = Some(ch) }
                             term || ch.is_whitespace()

--- a/src/sequence_of_non-squares.rs
+++ b/src/sequence_of_non-squares.rs
@@ -16,7 +16,7 @@ fn main() {
 #[test]
 fn test_no_squares() {
     // check if a number is a square
-    let is_square = |&: n: u64| { let r = (n as f64).sqrt() as u64; r * r == n };
+    let is_square = |n: u64| { let r = (n as f64).sqrt() as u64; r * r == n };
     // verify that there are no squares in the first million of
     // values calculated by non_sq
     for ns in (1u64..1000001).map(non_sq) {

--- a/src/webserver.rs
+++ b/src/webserver.rs
@@ -1,14 +1,17 @@
 // Implements http://rosettacode.org/wiki/Hello_world/Web_server
+#![allow(unused_features)]
 #![feature(io)]
 #![feature(std_misc)]
 #![feature(os)]
+#![feature(env)]
 #![feature(core)]
+#![feature(std_misc)]
 
 use std::old_io::net::tcp::{TcpAcceptor, TcpListener, TcpStream};
 use std::old_io::{Acceptor, Listener, IoResult};
 use std::thread::Thread;
 
-#[cfg(not(test))] use std::os;
+#[cfg(not(test))] use std::env;
 
 fn handle_client(mut stream: TcpStream) -> IoResult<()> {
     let response =
@@ -64,11 +67,14 @@ pub fn handle_server(ip: &str, port: u16) -> IoResult<TcpAcceptor> {
 
 #[cfg(not(test))]
 fn main() {
-    let args = os::args();
-
+    let mut args = env::args();
+    let app_name = args.next().unwrap()
+        .into_string().unwrap();
     let host = "127.0.0.1";
-    let port = if args.len() == 2 {
-        args[1].parse::<u16>().ok().expect(&*format!("Usage: {} <port>", args[0]))
+    let port = if let Some(os_port) = args.next() {
+        let s_port = os_port.into_string().unwrap();
+        s_port.parse::<u16>().ok()
+            .expect(&*format!("Usage: {:?} <port>", app_name))
     } else {
         80
     };

--- a/src/write_ppm.rs
+++ b/src/write_ppm.rs
@@ -4,6 +4,7 @@
 #![feature(io)]
 #![feature(path)]
 #![feature(core)]
+extern crate rand;
 
 use std::old_io::{File, BufferedWriter, IoResult};
 use bitmap::Image;
@@ -48,8 +49,8 @@ pub fn main() {
 mod test {
     use bitmap::{Color, Image};
     use std::old_io::{File, BufferedReader};
-    use std::rand;
-    use std::rand::Rng;
+    use rand;
+    use rand::Rng;
     use std::os;
 
     #[test]


### PR DESCRIPTION
- closures don't need |&: |& and |: any longer
- std::env::args() replaces std::os:args()
- rand is now an external library