### PR TITLE
Add build script to check for correct formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,13 +7,7 @@ dependencies = [
  "regex 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex_macros 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "gcc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
@@ -65,13 +59,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "rustc-serialize"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "time"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "gcc 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "rust-rosetta"
 version = "0.0.1"
+build = "build.rs"
 authors = [
     "Andrew Hobden, https://github.com/Hoverbear",
     "Adolfo Ochagavía, https://github.com/aochagavia",

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,53 @@
+// This build script checks that all files in the `src` directory have lines of at most 100
+// characters and don't contain trailing whitespace.
+//
+// In case we find a line that doesn't comply with this rules, the build will fail and indicate
+// the cause of the problem.
+
+#![feature(io, fs, path)]
+
+use std::fs::{self, File, PathExt};
+use std::io::Read;
+use std::path::Path;
+
+fn main() {
+    let files = fs::read_dir("src").unwrap()
+                                   .map(|e| e.unwrap());
+
+    for f in files {
+        let path = f.path();
+        if path.is_file() {
+            check(&path);
+        }
+    }
+}
+
+fn check(path: &Path) {
+    let mut content = String::new();
+    File::open(&path).unwrap().read_to_string(&mut content).unwrap();
+    
+    for (i, mut line) in content.lines().enumerate() {
+        // Ignore '\r'
+        if let Some('\r') = line.chars().rev().next() {
+            line = &line[..line.len() - 1];
+        }
+    
+        // Check length
+        if line.len() > 100 {
+            line_error(i + 1, path, "line is longer than 100 characters");
+        }
+        
+        // Check trailing whitespace
+        if let Some(last_char) = line.chars().rev().next() {
+            if last_char.is_whitespace() {
+                line_error(i + 1, path, "line has trailing whitespace");
+            }
+        }
+        
+    }
+}
+
+fn line_error(line: usize, path: &Path, msg: &str) {
+    panic!("Formatting error, {} (line {} of file \"{}\")",
+           msg, line, path.to_str().unwrap())
+}


### PR DESCRIPTION
Closes https://github.com/Hoverbear/rust-rosetta/issues/238

*I still need to cleanup the files to match the formatting rules