### PR TITLE
Fixed compilation errors and almost all deprecations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 name = "rust-rosetta"
 version = "0.0.1"
 dependencies = [
- "num 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex_macros 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/active_object.rs
+++ b/src/active_object.rs
@@ -1,11 +1,12 @@
 // Implements http://rosettacode.org/wiki/Active_object
 #![feature(std_misc)]
 #![feature(old_io)]
-#![feature(core)]
 
 extern crate time;
+extern crate num;
 
-use std::num::Float;
+use num::traits::Zero;
+use num::Float;
 use std::f64::consts::PI;
 use std::old_io::timer::Timer;
 use std::sync::{Arc, Mutex};
@@ -35,7 +36,7 @@ pub struct Integrator<S: 'static, T: Send> {
 // function being integrated) must yield T (the type of the integrated value) when multiplied by
 // f64.  We could possibly replace f64 with a generic as well, but it would make things a bit more
 // complex.
-impl<S: Mul<f64, Output=T> + Float,
+impl<S: Mul<f64, Output=T> + Float + Zero,
      T: 'static + Clone + Send + Float> Integrator<S, T> {
     pub fn new(frequency: Duration) -> Integrator<S, T> {
         // We create a pipe allowing functions to be sent from tx (the sending end) to input (the
@@ -47,7 +48,7 @@ impl<S: Mul<f64, Output=T> + Float,
         // that memory will not be freed as long as there is at least one reference to it.
         // It is similar to C++'s shared_ptr, but it is guaranteed to be safe and is never
         // incremented unless explicitly cloned (by default, it is moved).
-        let s: Arc<Mutex<T>> = Arc::new(Mutex::new(Float::zero()));
+        let s: Arc<Mutex<T>> = Arc::new(Mutex::new(Zero::zero()));
         let integrator = Integrator {
             input: tx,
             // Here is the aforementioned clone.  We have to do it before s enters the closure,
@@ -71,8 +72,8 @@ impl<S: Mul<f64, Output=T> + Float,
             let periodic = timer.periodic(frequency);
             let frequency_ms = frequency.num_milliseconds();
             let mut t = 0;
-            let mut k: Box<Fn(i64) -> S + Send> = Box::new(|_| Float::zero());
-            let mut k_0: S = Float::zero();
+            let mut k: Box<Fn(i64) -> S + Send> = Box::new(|_| Zero::zero());
+            let mut k_0: S = Zero::zero();
             loop {
                 // Here's the selection we talked about above.  Note that we are careful to call
                 // the *non*-failing function, recv(), here.  The reason we do this is because

--- a/src/agm.rs
+++ b/src/agm.rs
@@ -2,10 +2,9 @@
 // Accepts two command line arguments
 // cargo run --name agm arg1 arg2
 
- // feature(os) is used only in main
-#![feature(std_misc)]
+extern crate num;
 
-use std::num::Float;
+use num::abs;
 
 #[cfg(not(test))]
 fn main () {
@@ -17,10 +16,6 @@ fn main () {
 
     let result = agm(x,y);
     println!("The arithmetic-geometric mean is {}", result);
-}
-
-fn abs<T: Float>(n: T) -> T {
-    if n < Float::zero() { -n } else { n }
 }
 
 fn agm (x: f32, y: f32) -> f32 {

--- a/src/aks_test_for_primes.rs
+++ b/src/aks_test_for_primes.rs
@@ -66,5 +66,5 @@ fn test_solution() {
     }
 
     let primes: Vec<u32> = (1..51).filter(|&i| is_prime(i)).collect();
-    assert_eq!(exp_primes, primes);
+    assert_eq!(exp_primes, &primes[..]);
 }

--- a/src/averages_mean_angle.rs
+++ b/src/averages_mean_angle.rs
@@ -1,7 +1,5 @@
 // Implements http://rosettacode.org/wiki/Averages/Mean_angle
-#![feature(core)]
 
-use std::num::Float;
 use std::f64::consts::PI;
 
 fn mean_angle(angles: &[f64]) -> f64 {

--- a/src/benford.rs
+++ b/src/benford.rs
@@ -5,7 +5,6 @@
 
 use std::fs::File;
 use std::io::{BufReader, BufRead};
-use std::num::Float;
 
 // Calculate the expected frequency of a digit according to Benford's Law
 fn benford_freq(d: u64) -> f32 {

--- a/src/binomial_coefficients.rs
+++ b/src/binomial_coefficients.rs
@@ -1,7 +1,6 @@
 // http://rosettacode.org/wiki/Evaluate_binomial_coefficients
-#![cfg_attr(test, feature(core))]
-
 extern crate num;
+
 use num::One;
 use num::bigint::{BigUint, ToBigUint};
 
@@ -32,13 +31,13 @@ fn main() {
 #[test]
 
 fn test_binomial() {
-    use std::num::FromStrRadix;
+    use num::traits::Num;
 
     assert_eq!(binomial(20, 0), binomial(20, 20));
     assert_eq!(binomial(20, 15), binomial(19, 14) + binomial(19, 15));
     assert_eq!(binomial(5, 3), 10.to_biguint().unwrap());
     assert_eq!(binomial(31, 17), 265182525.to_biguint().unwrap());
     assert_eq!(binomial(300, 30),
-        FromStrRadix::from_str_radix("173193226149263513034110205899732811401360", 10).unwrap());
+        BigUint::from_str_radix("173193226149263513034110205899732811401360", 10).unwrap());
 }
 

--- a/src/closest-pair.rs
+++ b/src/closest-pair.rs
@@ -6,10 +6,8 @@
 // of the divide-and-conquer algorithm, since it's (arguably)
 // easier to implement, and an efficient implementation does not require
 // use of unsafe.
-#![feature(std_misc)]
 extern crate num;
 
-use std::num::Float;
 use std::cmp::{PartialOrd, Ordering};
 use num::complex::Complex;
 use std::collections::BTreeSet;
@@ -70,7 +68,7 @@ fn closest_pair(points: &mut [Point]) -> Option<(Point, Point)> {
         // Compare to points in bounding box
         {
             let low_bound = YSortedPoint {
-                point: Point { re: std::num::Float::infinity(), im: point.im - closest_distance }
+                point: Point { re: ::std::f32::INFINITY, im: point.im - closest_distance }
             };
             let mut strip_iter = strip.iter().skip_while(|&p| p < &low_bound);
             loop {
@@ -121,7 +119,6 @@ pub fn main() {
 mod test {
     use super::closest_pair;
     use num::complex::Complex;
-    use std::num::Float;
 
     #[test]
     fn random_floats() {

--- a/src/closures-value_capture.rs
+++ b/src/closures-value_capture.rs
@@ -1,6 +1,5 @@
 // http://rosettacode.org/wiki/Closures/Value_capture
 use std::iter::Map;
-use std::num::Float;
 use std::ops::RangeFrom;
 
 #[allow(dead_code)]
@@ -39,7 +38,6 @@ fn main() {
 
 #[cfg(test)]
 mod test {
-    use std::num::Float;
     use super::{closure_gen, closures_iterator};
 
     #[test]

--- a/src/concurrent_computing.rs
+++ b/src/concurrent_computing.rs
@@ -1,10 +1,7 @@
 // Implements http://rosettacode.org/wiki/Concurrent_computing
-#![feature(std_misc)]
-#![feature(thread_sleep)]
 extern crate rand;
-use std::thread::sleep;
+use std::thread::sleep_ms;
 use rand::random;
-use std::time::duration::Duration;
 use std::thread::spawn;
 
 fn main() {
@@ -13,7 +10,7 @@ fn main() {
     for s in strings.into_iter(){
         spawn(move || -> () {
             // We use a random u8 (so an integer from 0 to 255)
-            sleep(Duration::milliseconds(random::<u8>() as i64));
+            sleep_ms(random::<u8>() as u32);
             println!("{}", s);
         });
     }

--- a/src/entropy.rs
+++ b/src/entropy.rs
@@ -2,7 +2,6 @@
 #![allow(unused_attributes)]
 #![allow(unused_features)]
 #![cfg_attr(test, feature(std_misc))]
-use std::num::Float;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 

--- a/src/equilibrium_index.rs
+++ b/src/equilibrium_index.rs
@@ -1,12 +1,13 @@
 // http://rosettacode.org/wiki/Equilibrium_index
 #![feature(core)]
+extern crate num;
 
+use num::traits::Zero;
 use std::iter::AdditiveIterator;
-use std::num::Int;
 
 fn equilibrium_indices(v: &[i32]) -> Vec<usize> {
     let mut right = v.iter().map(|&x| x).sum();
-    let mut left: i32 = Int::zero();
+    let mut left = i32::zero();
 
     v.iter().enumerate().fold(vec![], |mut out, (i, &el)| {
         // NOTE: -= and += doesn't work on left/right and el for some reason.

--- a/src/factor_int.rs
+++ b/src/factor_int.rs
@@ -1,7 +1,5 @@
 // Implements http://rosettacode.org/wiki/Factors_of_an_integer
 
-use std::num::Float;
-
 #[cfg(not(test))]
 fn main() {
     let target = 78i32;

--- a/src/fast_fourier_transform.rs
+++ b/src/fast_fourier_transform.rs
@@ -1,5 +1,4 @@
 // Implements http://rosettacode.org/wiki/Fast_Fourier_transform
-#![feature(core)]
 extern crate num;
 
 use std::f32::consts::PI;

--- a/src/fibonacci_word.rs
+++ b/src/fibonacci_word.rs
@@ -41,7 +41,6 @@ fn main() {
 }
 #[test]
 fn test_fibonacii_words() {
-    use std::num::Float;
 
     let expected = vec![
         (1, 0.000000000000000f64),

--- a/src/flatten_list.rs
+++ b/src/flatten_list.rs
@@ -1,38 +1,12 @@
 //http://rosettacode.org/wiki/Flatten_a_list
 
 #![feature(box_syntax)]
-use std::fmt;
 use Tree::{Node, Leaf};
 
 #[derive(Debug)]
 enum Tree<T>{
     Node(Vec<Tree<T>>),
     Leaf(T),
-}
-
-/// fmt::Display is implemented here for pretty printing.
-impl<T> fmt::Display for Tree<T>
-    where T: fmt::Display {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result{
-        match *self {
-            Node(ref vec) => write!(f, "{}", vec),
-            Leaf(ref val) => write!(f, "{}", val)
-        }
-    }
-}
-
-impl<T> fmt::Display for Vec<Tree<T>>
-    where T: fmt::Display {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut first = true;
-        try!(write!(f, "["));
-        for x in self.iter(){
-            if !first { try!(write!(f, ", ")); }
-            try!(write!(f, "{}", *x));
-            first = false;
-        }
-        write!(f, "]")
-    }
 }
 
 fn flatten<T>(tree: Tree<T>) -> Vec<T>{
@@ -58,7 +32,7 @@ fn main() {
             Node(vec![])
             ]);
 
-    println!("{}", list);
+    println!("{:?}", list);
 
     let flattened = flatten(list);
 
@@ -79,7 +53,7 @@ fn rosetta_flatten_test() {
             Node(vec![])
             ]);
 
-    println!("{}", list);
+    println!("{:?}", list);
 
     let flattened = flatten(list);
 

--- a/src/four_bit_adder.rs
+++ b/src/four_bit_adder.rs
@@ -1,7 +1,6 @@
 // Implements http://rosettacode.org/wiki/Four_bit_adder
-#![feature(core)]
 use std::ops::Deref;
-use std::{fmt, num};
+use std::fmt;
 
 // primitive gates
 fn not(a: bool) -> bool { !a }
@@ -38,7 +37,7 @@ impl Nibble {
   }
 
   fn to_u8(&self, carry: bool) -> u8 {
-    match num::from_str_radix::<u8>(&(format!("{}", self))[..], 2) {
+    match u8::from_str_radix(&(format!("{}", self))[..], 2) {
       Ok(n) if carry => n + 16,
       Ok(n) => n,
       Err(_) => unreachable!()

--- a/src/function_composition.rs
+++ b/src/function_composition.rs
@@ -1,6 +1,4 @@
 // http://rosettacode.org/wiki/Function_composition
-#![cfg_attr(not(test), feature(core))]
-
 #[cfg(not(test))]
 fn main() {
     use std::f32::consts;

--- a/src/handle_a_signal.rs
+++ b/src/handle_a_signal.rs
@@ -3,6 +3,7 @@
 // Note that this solution only works on Unix.
 #![feature(libc)]
 #![cfg_attr(unix, feature(old_io))]
+#![cfg_attr(unix, feature(std_misc))]
 
 extern crate libc;
 extern crate time;

--- a/src/horners_rule.rs
+++ b/src/horners_rule.rs
@@ -1,10 +1,10 @@
 // http://rosettacode.org/wiki/Horner%27s_rule_for_polynomial_evaluation
-#![feature(core)]
-use std::num::Int;
+extern crate num;
 
+use num::traits::{PrimInt, Zero};
 
-fn horner<T:Int>(cs:&[T], x:T) -> T {
-    cs.iter().rev().fold(Int::zero(), |acc: T, c| (acc*x) + (*c))
+fn horner<T: PrimInt + Zero>(cs:&[T], x:T) -> T {
+    cs.iter().rev().fold(Zero::zero(), |acc: T, c| (acc*x) + (*c))
 }
 
 #[cfg(not(test))]

--- a/src/hough_transform.rs
+++ b/src/hough_transform.rs
@@ -2,10 +2,6 @@
 //
 // Contributed by Gavin Baker <gavinb@antonym.org>
 // Adapted from the Go version
-#![feature(std_misc)]
-#![feature(core)]
-
-use std::num::Float;
 use std::io::{BufReader, BufRead, BufWriter, Write, Read};
 use std::fs::File;
 use std::iter::repeat;

--- a/src/infinity.rs
+++ b/src/infinity.rs
@@ -1,8 +1,6 @@
 // Implements http://rosettacode.org/wiki/Infinity
-#![feature(std_misc)]
-use std::num::Float;
 
 fn main() {
-    let inf : f32 = Float::infinity();
+    let inf = ::std::f32::INFINITY;
     println!("{}", inf);
 }

--- a/src/isaac.rs
+++ b/src/isaac.rs
@@ -1,8 +1,7 @@
 // http://rosettacode.org/wiki/The_ISAAC_Cipher
 // includes the XOR version of the encryption scheme
-#![feature(core)]
 #![feature(step_by)]
-use std::num::wrapping::Wrapping as w;
+use std::num::Wrapping as w;
 
 const MSG :&'static str = "a Top Secret secret";
 const KEY: &'static str = "this is my secret key";

--- a/src/k-d-tree.rs
+++ b/src/k-d-tree.rs
@@ -1,11 +1,8 @@
 // Implements http://rosettacode.org/wiki/K-d_tree
 
-
-
 extern crate time;
 extern crate rand;
 
-use std::num::Float;
 use rand::Rng;
 use std::cmp::Ordering;
 #[cfg(not(test))]

--- a/src/kahansum.rs
+++ b/src/kahansum.rs
@@ -1,9 +1,10 @@
 // Implements http://rosettacode.org/wiki/Kahan_summation
 #![feature(std_misc)]
 #![feature(collections)]
+extern crate num;
 
-use std::num::Float;
 use std::f32;
+use num::Float;
 
 fn find_max(lst: &[f32]) -> Option<f32> {
     if lst.is_empty() { return None }

--- a/src/linear_congruential_generator.rs
+++ b/src/linear_congruential_generator.rs
@@ -1,6 +1,5 @@
 // Implements http://rosettacode.org/wiki/Linear_congruential_generator
-#![feature(core)]
-use std::num::wrapping::Wrapping as w;
+use std::num::Wrapping as w;
 
 trait LinearCongruentialGenerator {
     fn seed(&mut self, seed: u32);

--- a/src/md5-implementation.rs
+++ b/src/md5-implementation.rs
@@ -3,13 +3,11 @@
  * Ported from C - Simple MD5 implementation
 * on Wikipedia https://en.wikipedia.org/wiki/MD5
 */
-#![feature(core)]
 #![feature(step_by)]
 #![feature(collections)]
 
-use std::num::wrapping::Wrapping as wr;
+use std::num::Wrapping as wr;
 use std::fmt::{Debug, Formatter, Result};
-use std::num::Int;
 
 #[cfg(not(test))]
 fn main() {
@@ -158,7 +156,7 @@ fn md5(initial_msg: &[u8]) -> MD5
 
 #[test]
 fn helper_fns() {
-    assert_eq!(64, 8.rotate_left(3));
+    assert_eq!(64, 8u32.rotate_left(3));
 
     let exp:[u8; 8] = [64u8, 226, 1, 0, 0, 0, 0, 0];
     assert!(to_bytes(123456) == exp);

--- a/src/metered_concurrency.rs
+++ b/src/metered_concurrency.rs
@@ -3,19 +3,16 @@
 // directly.
 
 #![feature(unsafe_destructor)]
-#![feature(std_misc)]
-#![feature(thread_sleep)]
 
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::SeqCst;
-use std::time::duration::Duration;
 use std::thread::{self, spawn};
 use std::sync::mpsc::channel;
 
 pub struct CountingSemaphore {
     count: AtomicUsize, // Remaining resource count
-    backoff: Duration, // How long to sleep if a resource is being contended
+    backoff: u32, // How long to sleep if a resource is being contended
 }
 
 pub struct CountingSemaphoreGuard<'a> {
@@ -25,14 +22,14 @@ pub struct CountingSemaphoreGuard<'a> {
 impl CountingSemaphore {
     // Create a semaphore with `max` available resources and a linearly increasing backoff of
     // `backoff` (used during spinlock contention).
-    pub fn new(max: usize, backoff: Duration) -> CountingSemaphore {
+    pub fn new(max: usize, backoff: u32) -> CountingSemaphore {
         CountingSemaphore { count: AtomicUsize::new(max), backoff: backoff }
     }
 
     // Acquire a resource, returning a RAII CountingSemaphoreGuard.
     pub fn acquire(&self) -> CountingSemaphoreGuard {
         // Spinlock until remaining resource count is at least 1
-        let mut backoff: Duration = self.backoff;
+        let mut backoff = self.backoff;
         loop {
             // Probably don't need SeqCst here, but it doesn't hurt.
             let count = self.count.load(SeqCst);
@@ -40,7 +37,7 @@ impl CountingSemaphore {
             // must be a compare-and-swap rather than a straight decrement.
             if count == 0 || self.count.compare_and_swap(count, count-1, SeqCst) != count {
                 // Linear backoff a la Servo's spinlock contention.
-                thread::sleep(backoff);
+                thread::sleep_ms(backoff);
                 backoff = backoff + self.backoff;
             } else {
                 // We successfully acquired the resource.
@@ -64,10 +61,10 @@ impl<'a> Drop for CountingSemaphoreGuard<'a> {
     }
 }
 
-fn metered(duration: Duration) {
+fn metered(duration: u32) {
     static MAX_COUNT: usize = 4; // Total available resources
     static NUM_WORKERS: u8 = 10; // Number of workers contending for the resources
-    let backoff = Duration::milliseconds(1); // Linear backoff time
+    let backoff = 1; // Linear backoff time
     // Create a shared reference to the semaphore
     let sem = Arc::new(CountingSemaphore::new(MAX_COUNT, backoff));
     // Create a channel for notifying the main task that the workers are done
@@ -83,7 +80,7 @@ fn metered(duration: Duration) {
             assert!(count < MAX_COUNT);
             println!("Worker {} after acquire: count = {}", i, count);
             // Sleep for `duration`
-            thread::sleep(duration);
+            thread::sleep_ms(duration);
             // Release the resource
             drop(guard);
             // Make sure the count is legal
@@ -104,11 +101,11 @@ fn metered(duration: Duration) {
 #[test]
 fn test_metered_concurrency() {
     // Hold each resource for 1/20 of a second per worker
-    metered(Duration::seconds(1) / 20);
+    metered(1000 / 20);
 }
 
 #[cfg(not(test))]
 fn main() {
     // Hold each resource for 2 seconds per worker
-    metered(Duration::seconds(2));
+    metered(2000);
 }

--- a/src/pernicious_numbers.rs
+++ b/src/pernicious_numbers.rs
@@ -1,9 +1,7 @@
 // http://rosettacode.org/wiki/Pernicious_numbers
 #![allow(unused_attributes)]
-#![feature(core)]
 
 use std::iter::Filter;
-use std::num::Int;
 use std::ops::RangeFrom;
 use aks_test_for_primes::is_prime;
 mod aks_test_for_primes;

--- a/src/population_count.rs
+++ b/src/population_count.rs
@@ -1,8 +1,6 @@
 // http://rosettacode.org/wiki/Population_count
-#![feature(core)]
 
 use std::iter::{Filter, Map};
-use std::num::Int;
 use std::ops::RangeFrom;
 
 #[cfg(not(test))]

--- a/src/primality_trial_div.rs
+++ b/src/primality_trial_div.rs
@@ -1,6 +1,5 @@
 //Implements http://rosettacode.org/wiki/Primality_by_Trial_Division
 #![feature(step_by)]
-use std::num::Float;
 
 fn is_prime(number: i32) -> bool {
     if number % 2 == 0 && number != 2 {

--- a/src/prime_decomposition.rs
+++ b/src/prime_decomposition.rs
@@ -1,7 +1,5 @@
 // Implements http://rosettacode.org/wiki/Prime_decomposition
 
-use std::num::Float;
-
 // We need this to be public because it is used from another file
 pub fn factor(mut nb: usize) -> Vec<usize> {
     let mut result = vec!();

--- a/src/proper_divisors.rs
+++ b/src/proper_divisors.rs
@@ -1,5 +1,4 @@
 // Implements http://rosettacode.org/wiki/Proper_divisors
-use std::num::Float;
 
 // Populate input vector with prime numbers < maxvalue
 fn add_more_prime_numbers(v:&mut Vec<usize>,maxvalue:usize) {

--- a/src/pythagorean_triples.rs
+++ b/src/pythagorean_triples.rs
@@ -1,8 +1,5 @@
 // http://rosettacode.org/wiki/Pythagorean_triples
-#![feature(core)]
-
 use std::collections::LinkedList;
-use std::num::Int;
 
 /// Count the number of Pythagorean triples whose sum are below the specified limit (inclusive).
 /// Does a BFS over the tree of primitive Pythagorean triples (see [0]), and uses the fact that

--- a/src/roots_of_a_function.rs
+++ b/src/roots_of_a_function.rs
@@ -1,7 +1,7 @@
 // http://rosettacode.org/wiki/Roots_of_a_function
+extern crate num;
 
-
-use std::num::Float;
+use num::Float;
 
 // Note: We cannot use `range_step` here because Floats don't implement
 // the `CheckedAdd` trait.

--- a/src/roots_of_unity.rs
+++ b/src/roots_of_unity.rs
@@ -1,5 +1,4 @@
 // http://rosettacode.org/wiki/Roots_of_unity
-#![feature(core)]
 
 extern crate num;
 use num::complex::{Complex, Complex32};

--- a/src/sequence_of_non-squares.rs
+++ b/src/sequence_of_non-squares.rs
@@ -1,7 +1,5 @@
 // http://rosettacode.org/wiki/Sequence_of_non-squares
 
-use std::num::Float;
-
 // the formula that should produce no perfect squares
 fn non_sq(n: u64) -> u64 { (n + ( 0.5 + (n as f64).sqrt()) as u64) }
 

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -3,7 +3,7 @@
 // library implementation
 #![feature(core)]
 
-use std::num::wrapping::Wrapping as wr;
+use std::num::Wrapping as wr;
 use std::slice::bytes::copy_memory;
 use std::io::{Write, Result};
 
@@ -189,7 +189,7 @@ impl Write for Digest {
         let ln=buf_m.len();
         if ln > 0 {
             assert!(self.x.len() >= ln);
-            copy_memory(&mut self.x, buf_m);
+            copy_memory(buf_m, &mut self.x);
             self.nx = ln;
         }
         Ok(())

--- a/src/sieve_eratosthenes.rs
+++ b/src/sieve_eratosthenes.rs
@@ -2,7 +2,6 @@
 #![feature(step_by)]
 
 use std::iter::repeat;
-use std::num::Float;
 
 fn int_sqrt(n: usize) -> usize {
     (n as f64).sqrt() as usize

--- a/src/sudoku.rs
+++ b/src/sudoku.rs
@@ -3,7 +3,6 @@
 #![feature(step_by)]
 use std::fmt;
 use std::str::FromStr;
-use std::num::Int;
 
 const BOARD_WIDTH: usize = 9;
 const BOARD_HEIGHT: usize = 9;

--- a/src/taxicab_numbers.rs
+++ b/src/taxicab_numbers.rs
@@ -1,8 +1,6 @@
 // http://rosettacode.org/wiki/Taxicab_numbers
-#![feature(core)]
 
 use std::collections::BinaryHeap;
-use std::num::Int;
 use std::cmp::Ordering;
 
 /// A type to represent a pair-sum of cubes.

--- a/src/walk_recursive.rs
+++ b/src/walk_recursive.rs
@@ -2,7 +2,6 @@
 #![feature(plugin)]
 #![plugin(regex_macros)]
 #![cfg_attr(test, feature(std_misc))]
-#![feature(convert)]
 extern crate regex;
 
 use regex::Regex;

--- a/src/wireworld.rs
+++ b/src/wireworld.rs
@@ -1,8 +1,6 @@
 // Implements http://rosettacode.org/wiki/Wireworld
-#![feature(std_misc, thread_sleep)]
 
 use std::mem;
-use std::time::duration::Duration;
 
 // Use VT100 cursor control sequences to animate in-place
 #[cfg(not(test))] const ANIMATE: bool = true;
@@ -55,7 +53,7 @@ fn next_world(input: &[Cell], output: &mut [Cell], w: usize, h: usize) {
 
 #[cfg(not(test))]
 fn main() {
-    use std::thread::sleep;
+    use std::thread::sleep_ms;
     let (w, h) = (14usize, 7usize);
     let mut world: Vec<Cell> = "
 +-----------+
@@ -79,7 +77,7 @@ fn main() {
         if ANIMATE {
             print!("\x1b[{}A", 8);
             print!("\x1b[{}D", 14);
-            sleep(Duration::milliseconds(100));
+            sleep_ms(100);
         }
     }
 }

--- a/src/write_ppm.rs
+++ b/src/write_ppm.rs
@@ -73,12 +73,12 @@ mod test {
         let _ = reader.read_line(&mut line);
         assert_eq!(line, "2 1 255\n");
         let mut bytes = reader.bytes();
-        assert_eq!(bytes.next().unwrap(), Ok(49));
-        assert_eq!(bytes.next().unwrap(), Ok(50));
-        assert_eq!(bytes.next().unwrap(), Ok(51));
-        assert_eq!(bytes.next().unwrap(), Ok(52));
-        assert_eq!(bytes.next().unwrap(), Ok(53));
-        assert_eq!(bytes.next().unwrap(), Ok(54));
+        assert_eq!(bytes.next().unwrap().unwrap(), 49);
+        assert_eq!(bytes.next().unwrap().unwrap(), 50);
+        assert_eq!(bytes.next().unwrap().unwrap(), 51);
+        assert_eq!(bytes.next().unwrap().unwrap(), 52);
+        assert_eq!(bytes.next().unwrap().unwrap(), 53);
+        assert_eq!(bytes.next().unwrap().unwrap(), 54);
         assert!(bytes.next().is_none());
     }
 }


### PR DESCRIPTION
The only deprecated object that remains is `std::old_io::timer::Timer`.