### PR TITLE
Fix print! usage

### DIFF
--- a/src/24_game_rpn.rs
+++ b/src/24_game_rpn.rs
@@ -5,11 +5,12 @@ extern crate rand;
 
 #[cfg(not(test))]
 fn main() {
-    use rand::{thread_rng, Rng};
-    use std::io;
+    use rand::Rng;
+    use std::io::{self, Write};
 
-    let mut rng = thread_rng();
-    let mut reader = io::stdin();
+    let mut rng = rand::thread_rng();
+    let mut stdin = io::stdin();
+    let mut stdout = io::stdout();
 
     // generating 4 numbers
     let choices: Vec<u32> = (0u32..4).map(
@@ -18,18 +19,20 @@ fn main() {
     println!("Make 24 with the following numbers");
 
     // start the game loop
+    let mut buffer = String::new();
     loop {
-        print!("Your numbers: {}, {}, {}, {}\n", choices[0], choices[1], choices[2], choices[3]);
-        let mut expr = String::new();
-        let _ = reader.read_line(&mut expr).ok().expect("Failed to read line!");
-        match check_input(&expr[..], &choices[..]) {
+        println!("Your numbers: {}, {}, {}, {}", choices[0], choices[1], choices[2], choices[3]);
+        buffer.clear();
+        stdin.read_line(&mut buffer).ok().expect("Failed to read line!");
+        match check_input(&buffer[..], &choices[..]) {
             Ok(()) => { println!("Good job!"); break; },
             Err(e) => println!("{}", e)
         }
         print!("Try again? (y/n): ");
-        let mut choice = String::new();
-        let _ = reader.read_line(&mut choice).ok().expect("Failed to read line!");
-        if choice.trim() != "y" { break; }
+        stdout.flush().unwrap();
+        buffer.clear();
+        stdin.read_line(&mut buffer).ok().expect("Failed to read line!");
+        if buffer.trim() != "y" { break; }
     }
 }
 

--- a/src/echo_server.rs
+++ b/src/echo_server.rs
@@ -38,9 +38,9 @@ fn echo_session(stream: TcpStream) -> io::Result<()> {
     let reader = BufReader::new(stream);
     for line in reader.lines() {
         let line = try!(line);
-        print!("Received line from {}: {}", addr, line);
+        println!("Received line from {}: {}", addr, line);
         try!(writer.write_all(line.as_bytes()));
-        print!("Wrote line to {}: {}", addr, line);
+        println!("Wrote line to {}: {}", addr, line);
     }
     Ok(())
 }

--- a/src/input_loop.rs
+++ b/src/input_loop.rs
@@ -4,6 +4,6 @@ use std::io::{self, BufRead};
 fn main() {
     let stdin = io::stdin();
     for line in stdin.lock().lines() {
-        print!("{}", line.unwrap());
+        println!("{}", line.unwrap());
     }
 }

--- a/src/synchronous_concurrency.rs
+++ b/src/synchronous_concurrency.rs
@@ -7,7 +7,7 @@
 use std::fs::File;
 use std::io::{BufReader, BufRead};
 use std::sync::mpsc::{channel, Sender, Receiver};
-use std::thread::spawn;
+use std::thread;
 
 const FILENAME: &'static str = "resources/input.txt";
 
@@ -21,7 +21,7 @@ fn printer(i_snd: Sender<i32>, msg_rcv: Receiver<Message>) {
     loop {
         match msg_rcv.recv().unwrap() {
             Message::Line(line) => {
-                print!("{}", line);
+                println!("{}", line);
                 count += 1;
             }
             Message::End => {break;}
@@ -36,13 +36,13 @@ fn reader(msg_snd: Sender<Message>, i_rcv: Receiver<i32>) {
         msg_snd.send(Message::Line(line.unwrap())).unwrap();
     }
     msg_snd.send(Message::End).unwrap();
-    println!("Total Lines: {:?}", i_rcv.recv());
+    println!("Total Lines: {}", i_rcv.recv().unwrap());
 }
 
 fn main() {
     let (msg_snd, msg_rcv) = channel();
     let (i_snd, i_rcv) = channel();
 
-    spawn(move || printer(i_snd, msg_rcv));
-    spawn(move || reader(msg_snd, i_rcv));
+    thread::spawn(move || printer(i_snd, msg_rcv));
+    thread::spawn(move || reader(msg_snd, i_rcv));
 }


### PR DESCRIPTION
`print!` doesn't automatically flush stdout anymore. This is a problem for programs that expect console input, since you typically want to show a prompt to the user.The problem is fixed by using `io::stdout().flush()` or by switching to `println!`.

Additionaly, I have replaced some usages of `print!` by `println!` because it made more sense.