### PR TITLE
Implement RSA

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -879,6 +879,11 @@ name = "rot13"
 path = "src/rot13.rs"
 
 [[bin]]
+# http://rosettacode.org/wiki/RSA_code
+name = "rsa_code"
+path = "src/rsa_code.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Run-length_encoding
 name = "run_length_encoding"
 path = "src/run_length_encoding.rs"

--- a/src/rsa_code.rs
+++ b/src/rsa_code.rs
@@ -1,0 +1,113 @@
+// Implements http://rosettacode.org/wiki/RSA_code
+extern crate num;
+
+use num::bigint::BigUint;
+use num::traits::{Zero, One};
+use num::integer::Integer;
+#[cfg(not(test))]
+use std::str::FromStr;
+
+fn mod_exp(b: &BigUint, e: &BigUint, n: &BigUint) -> Result<BigUint, &'static str> {
+    if n.is_zero() {
+        return Err("modulus is zero");
+    }
+    if b >= n {
+        // base is too large and should be split into blocks
+        return Err("base is >= modulus");
+    }
+    if b.gcd(n) != BigUint::one() {
+        return Err("base and modulus are not relatively prime");
+    }
+
+    let mut bb = b.clone();
+    let mut ee = e.clone();
+    let mut result = BigUint::one();
+    while !ee.is_zero() {
+        if ee.is_odd() {
+            result = (result * &bb) % n;
+        }
+        ee = ee >> 1;
+        bb = (&bb * &bb) % n;
+    }
+    Ok(result)
+}
+
+#[cfg(not(test))]
+fn main() {
+    let msg = "Rosetta Code";
+
+    let n = BigUint::from_str("9516311845790656153499716760847001433441357").unwrap();
+    let e = BigUint::from_str("65537").unwrap();
+    let d = BigUint::from_str("5617843187844953170308463622230283376298685").unwrap();
+
+    let msg_int = BigUint::from_bytes_be(msg.as_bytes());
+    let enc = mod_exp(&msg_int, &e, &n).unwrap();
+    let dec = mod_exp(&enc, &d, &n).unwrap();
+    let msg_dec = String::from_utf8(dec.to_bytes_be()).unwrap();
+
+    println!("msg as txt: {}", msg);
+    println!("msg as num: {}", msg_int);
+    println!("enc as num: {}", enc);
+    println!("dec as num: {}", dec);
+    println!("dec as txt: {}", msg_dec);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::mod_exp;
+    use std::str::FromStr;
+    use num::bigint::BigUint;
+    use num::integer::Integer;
+    use num::traits::{Zero, FromPrimitive};
+
+    const N: &'static str = "9516311845790656153499716760847001433441357";
+    const E: &'static str = "65537";
+    const D: &'static str = "5617843187844953170308463622230283376298685";
+
+    fn rsa_numbers() -> (BigUint, BigUint, BigUint) {
+        let n = BigUint::from_str(N).unwrap();
+        let e = BigUint::from_str(E).unwrap();
+        let d = BigUint::from_str(D).unwrap();
+        (n, e, d)
+    }
+
+    #[test]
+    fn test_enc_dec() {
+        let (n, e, d) = rsa_numbers();
+        let msg = "Rosetta Code";
+        let msg_int = BigUint::from_bytes_be(msg.as_bytes());
+        let enc = mod_exp(&msg_int, &e, &n).unwrap();
+        let dec = mod_exp(&enc, &d, &n).unwrap();
+        let msg_dec = String::from_utf8(dec.to_bytes_be()).unwrap();
+        assert_eq!(msg, msg_dec);
+    }
+
+    #[test]
+    fn test_enc_too_large_base() {
+        let (n, e, _) = rsa_numbers();
+        let msg = "I am too large for this modulus!";
+        let msg_int = BigUint::from_bytes_be(msg.as_bytes());
+        assert!(msg_int > n);
+        let result = mod_exp(&msg_int, &e, &n);
+        assert_eq!(Err("base is >= modulus"), result);
+    }
+
+    #[test]
+    fn test_enc_zero_modulus() {
+        let (_, e, _) = rsa_numbers();
+        let msg_int = BigUint::from_bytes_be("msg".as_bytes());
+        let result = mod_exp(&msg_int, &e, &BigUint::zero());
+        assert_eq!(Err("modulus is zero"), result);
+    }
+
+    #[test]
+    fn test_base_modulus_not_relatively_prime() {
+        let (_, e, _) = rsa_numbers();
+        let b = BigUint::from_u8(12).unwrap();
+        let n = BigUint::from_u8(18).unwrap();
+        assert_eq!(&BigUint::from_u8(6).unwrap(), &b.gcd(&n));
+        let result = mod_exp(&b, &e, &n);
+        assert_eq!(Err("base and modulus are not relatively prime"), result);
+    }
+}
+


### PR DESCRIPTION
Namely modular exponentiation part of the RSA, required by http://rosettacode.org/wiki/RSA_code

To keep the code concise, breaking the message into blocks is not supported (error is returned when the base is larger than the modulus).
Using homebrew mod_exp since BigUint does not have one (yet? :)).