### PR TITLE
Use rust nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,2 @@
 language: rust
+rust: nightly


### PR DESCRIPTION
It seems that Travis CI switched to rust stable. However, we use some unstable features and the build doesn't pass. Allowing nightly should fix it. Hopefully we will switch back to stable in the future.

cc @Hoverbear @pfalabella do you think this is a good idea?