### PR TITLE
parse() string into BigUint instead of using BigUint::from_str()

### DIFF
--- a/src/rsa_code.rs
+++ b/src/rsa_code.rs
@@ -4,8 +4,6 @@ extern crate num;
 use num::bigint::BigUint;
 use num::traits::{Zero, One};
 use num::integer::Integer;
-#[cfg(not(test))]
-use std::str::FromStr;
 
 fn mod_exp(b: &BigUint, e: &BigUint, n: &BigUint) -> Result<BigUint, &'static str> {
     if n.is_zero() {
@@ -36,9 +34,9 @@ fn mod_exp(b: &BigUint, e: &BigUint, n: &BigUint) -> Result<BigUint, &'static st
 fn main() {
     let msg = "Rosetta Code";
 
-    let n = BigUint::from_str("9516311845790656153499716760847001433441357").unwrap();
-    let e = BigUint::from_str("65537").unwrap();
-    let d = BigUint::from_str("5617843187844953170308463622230283376298685").unwrap();
+    let n = "9516311845790656153499716760847001433441357".parse().unwrap();
+    let e = "65537".parse().unwrap();
+    let d = "5617843187844953170308463622230283376298685".parse().unwrap();
 
     let msg_int = BigUint::from_bytes_be(msg.as_bytes());
     let enc = mod_exp(&msg_int, &e, &n).unwrap();
@@ -55,7 +53,6 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::mod_exp;
-    use std::str::FromStr;
     use num::bigint::BigUint;
     use num::integer::Integer;
     use num::traits::{Zero, FromPrimitive};
@@ -65,9 +62,9 @@ mod tests {
     const D: &'static str = "5617843187844953170308463622230283376298685";
 
     fn rsa_numbers() -> (BigUint, BigUint, BigUint) {
-        let n = BigUint::from_str(N).unwrap();
-        let e = BigUint::from_str(E).unwrap();
-        let d = BigUint::from_str(D).unwrap();
+        let n = N.parse().unwrap();
+        let e = E.parse().unwrap();
+        let d = D.parse().unwrap();
         (n, e, d)
     }
 


### PR DESCRIPTION
This addresses the issue referenced in https://github.com/Hoverbear/rust-rosetta/pull/392#discussion_r30707638

Using `parse()` looks more pretty to me as well. I have also noticed that there is no need to specify the type for `n, e` and `d` - it gets inferred when the values are passed to `mod_exp(BigUint, BigUint, BigUint)` or returned as a `BigUint` tuple (in the tests).