### PR TITLE
fixed errors on nightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,22 +3,34 @@ name = "rust-rosetta"
 version = "0.0.1"
 dependencies = [
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "num 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "schedule_recv 0.0.1 (git+https://github.com/PeterReid/schedule_recv)",
- "time 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "gcc"
-version = "0.3.5"
+name = "aho-corasick"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "lazy_static"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -27,12 +39,20 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "memchr"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "num"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -45,12 +65,22 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "0.1.30"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-serialize"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -58,16 +88,27 @@ name = "schedule_recv"
 version = "0.0.1"
 source = "git+https://github.com/PeterReid/schedule_recv#d2c5a10d0a5b88788c139f6823eafb62e7c3aa03"
 dependencies = [
- "lazy_static 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "time"
-version = "0.1.25"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-build"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 

--- a/src/24_game_solve.rs
+++ b/src/24_game_solve.rs
@@ -2,7 +2,7 @@
 
 // modeled after the scala solution
 // http://rosettacode.org/wiki/24_game/Solve#Scala
-#![feature(collections)]
+#![feature(permutations)]
 #![feature(slice_patterns)]
 
 extern crate num;

--- a/src/9_billion_names_of_god_the_integer.rs
+++ b/src/9_billion_names_of_god_the_integer.rs
@@ -25,7 +25,7 @@ impl Solver {
         (0..idx).map(|i| &r[i+1] - &r[i])
                      .map(|n| n.to_string())
                      .collect::<Vec<String>>()
-                     .connect(", ")
+                     .join(", ")
     }
 
     // Convenience method to access the last column in a culmulated calculation

--- a/src/active_object.rs
+++ b/src/active_object.rs
@@ -1,5 +1,5 @@
 // Implements http://rosettacode.org/wiki/Active_object
-#![feature(std_misc)]
+#![feature(mpsc_select)]
 
 extern crate time;
 extern crate num;

--- a/src/atomic_updates.rs
+++ b/src/atomic_updates.rs
@@ -8,7 +8,6 @@
 // we're using here was the fourth type I tried but the first to produce acceptable performance
 // (previously I tried, in order, std::sync::RwLock, std::sync::Mutex, and std::sync::Semaphore)
 // and this type still appears to have quite a bit of overhead.
-#![feature(core)]
 extern crate rand;
 
 use rand::{Rng, weak_rng};
@@ -223,9 +222,9 @@ fn display(bl: &buckets::Buckets, running: &AtomicBool, original_total: usize,
         // Get a consistent snapshot
         let (s, tc) = bl.snapshot();
         // Sum up the buckets
-        let sum = s.iter().map( |&i| i ).sum::<usize>();
+        let sum = s.iter().fold(0, |a, &b| a + b);
         // Sum up the transfers.
-        let n_transfers = tc.iter().map( |&i| i ).sum::<usize>();
+        let n_transfers = tc.iter().fold(0, |a, &b| a + b);
         // Print the relevant information.
         println!("{:?}, {}, {:?}, {}", tc, n_transfers, s, sum);
         // Check the invariant, failing if necessary.

--- a/src/comma_quibbling.rs
+++ b/src/comma_quibbling.rs
@@ -3,7 +3,7 @@ fn quibble(seq: &[&str]) -> String {
     match seq.len() {
         0 => "{}".to_string(),
         1 => format!("{{{}}}", seq[0] ),
-        _ => format!("{{{} and {}}}", seq[.. seq.len() - 1].connect(", "), seq.last().unwrap())
+        _ => format!("{{{} and {}}}", seq[.. seq.len() - 1].join(", "), seq.last().unwrap())
     }
 }
 

--- a/src/count_in_octal.rs
+++ b/src/count_in_octal.rs
@@ -1,5 +1,5 @@
 // Implements http://rosettacode.org/wiki/Count_in_octal
-#![feature(core)]
+#![feature(range_inclusive)]
 
 use std::u8;
 use std::iter::range_inclusive;

--- a/src/equilibrium_index.rs
+++ b/src/equilibrium_index.rs
@@ -1,11 +1,10 @@
 // http://rosettacode.org/wiki/Equilibrium_index
-#![feature(core)]
 extern crate num;
 
 use num::traits::Zero;
 
 fn equilibrium_indices(v: &[i32]) -> Vec<usize> {
-    let mut right = v.iter().map(|&x| x).sum();
+    let mut right = v.iter().fold(0, |a, &b| a + b);
     let mut left = i32::zero();
 
     v.iter().enumerate().fold(vec![], |mut out, (i, &el)| {

--- a/src/fibonacci_word.rs
+++ b/src/fibonacci_word.rs
@@ -1,5 +1,4 @@
 // Implements http://rosettacode.org/wiki/Fibonacci_word
-#![feature(collections)]
 use entropy::shannon_entropy;
 mod entropy;
 
@@ -8,8 +7,8 @@ mod entropy;
 // and the second one its entropy
 fn fib_words(amount: usize) -> Vec<(usize, f64)> {
     let mut data = Vec::with_capacity(amount);
-    let mut previous = String::from_str("1");
-    let mut next = String::from_str("0");
+    let mut previous = String::from("1");
+    let mut next = String::from("0");
 
     // The first two words (we need to add them manually because
     // they are the base of the sequence)

--- a/src/hailstone.rs
+++ b/src/hailstone.rs
@@ -1,6 +1,6 @@
 // Implements http://rosettacode.org/wiki/Hailstone_sequence
 // Define a struct which stores the state for the iterator.
-#![feature(core)]
+#![feature(iter_cmp)]
 
 struct Hailstone {
     next: usize, // Accessible only to the current module.

--- a/src/handle_a_signal.rs
+++ b/src/handle_a_signal.rs
@@ -13,7 +13,7 @@ fn main()
     use libc::funcs::posix01::signal;
     use std::mem;
     use std::sync::atomic::{AtomicBool, ATOMIC_BOOL_INIT, Ordering};
-    use time::duration::Duration;
+    use time::Duration;
 
     // The time between ticks of our counter.
     let duration = 500u32; //Duration::seconds(1) / 2;

--- a/src/kahansum.rs
+++ b/src/kahansum.rs
@@ -1,5 +1,5 @@
 // Implements http://rosettacode.org/wiki/Kahan_summation
-#![feature(collections)]
+#![feature(permutations)]
 extern crate num;
 
 use std::f32;

--- a/src/luhn_test.rs
+++ b/src/luhn_test.rs
@@ -1,25 +1,29 @@
 // Implements http://rosettacode.org/wiki/Luhn_test_of_credit_card_numbers
-#![feature(core)]
+struct Digits {
+    m: u64
+}
 
-use std::iter::Unfold;
+impl Iterator for Digits {
+    type Item = u64;
 
-#[derive(Copy, Clone)]
-enum LuhnState { Even, Odd, }
-
-type Digits = Unfold<u64, fn(&mut u64) -> Option<u64>>;
-
-fn digits(n: u64) -> Digits {
-    fn state(s: &mut u64) -> Option<u64> {
-       match *s {
+    fn next(&mut self) -> Option<u64> {
+        match self.m {
            0 => None,
            n => {
                let ret = n % 10;
-               *s = n / 10;
+               self.m = n / 10;
                Some(ret)
            }
        }
     }
-    Unfold::new(n, state as fn(&mut u64) -> Option<u64>)
+}
+
+#[derive(Copy, Clone)]
+enum LuhnState { Even, Odd, }
+
+
+fn digits(n: u64) -> Digits {
+    Digits{m: n}
 }
 
 fn luhn_test(n: u64) -> bool {

--- a/src/md5-implementation.rs
+++ b/src/md5-implementation.rs
@@ -4,7 +4,6 @@
 * on Wikipedia https://en.wikipedia.org/wiki/MD5
 */
 #![feature(step_by)]
-#![feature(collections)]
 
 use std::num::Wrapping as wr;
 use std::fmt::{Debug, Formatter, Result};
@@ -94,7 +93,7 @@ fn md5(initial_msg: &[u8]) -> MD5
     }
 
     // append the len in bits at the end of the buffer.
-    msg.push_all(&to_bytes(initial_len << 3));
+    msg.extend(&to_bytes(initial_len << 3));
 
     assert_eq!(msg.len() % 64, 0);
 

--- a/src/monte_carlo_methods.rs
+++ b/src/monte_carlo_methods.rs
@@ -1,9 +1,7 @@
 // http://rosettacode.org/wiki/Monte_Carlo_methods
 
-#![feature(core)]
 extern crate rand;
 use rand::Rng;
-use std::iter::iterate;
 
 #[inline]
 fn inside_circle(p:(f64, f64)) -> i64 {
@@ -25,7 +23,7 @@ fn simulate(time: i64) -> f64 {
 
 #[cfg(not(test))]
 pub fn main() {
-    for i in iterate(1000, |x| x*10).take(5) {
+    for i in (3..9).map(|a| 10i64.pow(a)) {
         println!("{:10}:{:.10}" , i, 4f64 * simulate(i));
     }
 }

--- a/src/n_queens.rs
+++ b/src/n_queens.rs
@@ -1,6 +1,5 @@
 // Implements http://rosettacode.org/wiki/N-queens_problem
 #![feature(test)]
-#![feature(core)]
 
 extern crate test;
 
@@ -131,7 +130,8 @@ fn semi_parallel_n_queens(n: i32) -> usize {
         });
     }
 
-    receivers.iter().map(|r| r.recv().unwrap()).sum::<usize>() + ((columns == all_ones) as usize)
+    receivers.iter().map(|r| r.recv().unwrap()).fold(0, |a, b| a + b) +
+        ((columns == all_ones) as usize)
 }
 
 // Tests

--- a/src/parallel_calculations.rs
+++ b/src/parallel_calculations.rs
@@ -1,9 +1,10 @@
 // Implements http://rosettacode.org/wiki/Parallel_calculations
 // See http://static.rust-lang.org/doc/master/guide-tasks.html for information
 // about tasks, channels, future, etc.
-#![feature(std_misc)]
 #![cfg_attr(test, feature(test))]
+#![feature(future)]
 
+#![cfg_attr(test, feature(test))]
 #[cfg(test)]
 extern crate test;
 

--- a/src/reverse_words_str.rs
+++ b/src/reverse_words_str.rs
@@ -1,11 +1,11 @@
 // Implements http://rosettacode.org/wiki/Reverse_words_in_a_string
 
 fn rev_words(line: &str) -> String {
-    line.split_whitespace().rev().collect::<Vec<&str>>().connect(" ")
+    line.split_whitespace().rev().collect::<Vec<&str>>().join(" ")
 }
 
 fn rev_words_on_lines(text: &str) -> String {
-     text.lines().map(rev_words).collect::<Vec<String>>().connect("\n")
+     text.lines().map(rev_words).collect::<Vec<String>>().join("\n")
 }
 
 #[cfg(not(test))]

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -1,7 +1,7 @@
 // Implements http://rosettacode.org/wiki/SHA-1
 // straight port from golang crypto/sha1
 // library implementation
-#![feature(core)]
+#![feature(slice_bytes)]
 
 use std::num::Wrapping as wr;
 use std::slice::bytes::copy_memory;

--- a/src/sudoku.rs
+++ b/src/sudoku.rs
@@ -1,5 +1,5 @@
 // http://rosettacode.org/wiki/Sudoku
-#![feature(core)]
+#![feature(iter_cmp)]
 #![feature(step_by)]
 use std::fmt;
 use std::str::FromStr;


### PR DESCRIPTION
fixed a  few errors/deprecations on latest 1.3 nightly

There are still at least a couple of deprecated items here and there (I added the feature to at least make them compile but left warnings as a reminder that they need to get fixed for good)
Valid-looking alternatives are starting to emerge on crates.io, but I'm not sure how currently usable they are.
Notably: 

 - Futures might be replaced by https://crates.io/crates/eventual
 - Permutations -> https://crates.io/crates/permutohedron