### PR TITLE
[RDY] Add subcrate to find differences between rust-rosetta repo and rosettacode.org

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,7 @@ name = "rust-rosetta"
 version = "0.0.1"
 dependencies = [
  "eventual 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "permutohedron 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -28,13 +29,29 @@ name = "aho-corasick"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "bitflags"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cookie"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "openssl 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "eventual"
@@ -51,8 +68,51 @@ name = "gag"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gcc"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "advapi32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hpack"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "httparse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "hyper"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cookie 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "httparse 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "language-tags 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solicit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "traitobject 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -65,6 +125,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "language-tags"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "lazy_static"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,6 +140,19 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "libc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libressl-pnacl-sys"
+version = "2.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "pnacl-build-helper 1.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "log"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,11 +161,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "matches"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "memchr"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mime"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -100,9 +191,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "openssl"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gcc 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libressl-pnacl-sys 2.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "permutohedron"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "pnacl-build-helper"
+version = "1.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rand"
@@ -120,7 +254,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -136,7 +270,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gag 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "termbox-sys 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -157,6 +291,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "solicit"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "hpack 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "syncbox"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,14 +309,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempdir"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tempfile"
-version = "1.1.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -189,6 +340,38 @@ dependencies = [
  "kernel32-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "traitobject"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "typeable"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicase"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "url"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,9 +67,10 @@ time = "*"
 rustc-serialize = "*"
 rand = "*"
 num = "*"
-libc="*"
+libc = "0.1.0"
 permutohedron = "*"
 eventual = "*"
+hyper = "0.6.15"
 
 # dependency does not compile on Windows, currently only used for 2048
 rustbox = { version = "*", optional = true }
@@ -935,6 +936,11 @@ path = "src/roots_of_a_function.rs"
 # http://rosettacode.org/wiki/Roots_of_unity
 name = "roots_of_unity"
 path = "src/roots_of_unity.rs"
+
+[[bin]]
+# http://rosettacode.org/wiki/Rosetta_Code/Find_unimplemented_tasks
+name = "rosetta_code_find_unimplemented_tasks"
+path = "src/rosetta_code/find_unimplemented_tasks.rs"
 
 [[bin]]
 # http://rosettacode.org/wiki/Rot-13

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,9 @@ hyper = "0.6.15"
 # dependency does not compile on Windows, currently only used for 2048
 rustbox = { version = "*", optional = true }
 
+[build-dependencies]
+regex = "0.1.41"
+
 [dependencies.schedule_recv]
 git = "https://github.com/PeterReid/schedule_recv"
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,17 @@ A repository for completing [this issue on mozilla/rust](https://github.com/mozi
 
 > Important: Not all `rust-rosetta` tasks exist in their current form on Rosetta Code. Please cross-check with this repository before you start.
 
+### Coverage ###
+
+The `coverage` subcrate contains commands that are useful for discovering
+incomplete solutions, or finding solutions that are different from the version
+posted to the Rosetta Code wiki. To see what commands are available:
+
+```sh
+$ cd coverage
+$ cargo run --release -- --help
+```
+
 ## Tasks Complete ##
 
 All tasks that have been completed are listed (along with a link to the problem) in [`Cargo.toml`](./Cargo.toml)

--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,17 @@
 // This build script checks that all files in the `src` directory have lines of at most 100
 // characters and don't contain trailing whitespace.
 //
+// It also ensures that comment indicating which task a file solves is at the top.
+//
 // In case we find a line that doesn't comply with this rules, the build will fail and indicate
 // the cause of the problem.
+extern crate regex;
 
 use std::fs::{self, File, metadata};
 use std::io::Read;
 use std::path::Path;
+
+use regex::Regex;
 
 fn main() {
     let files = fs::read_dir("src").unwrap()
@@ -23,25 +28,33 @@ fn main() {
 fn check(path: &Path) {
     let mut content = String::new();
     File::open(&path).unwrap().read_to_string(&mut content).unwrap();
-    
+
     for (i, mut line) in content.lines().enumerate() {
+        if i == 0 && path.file_name().unwrap() != "lib.rs" {
+            // Ensure the first line has a URL of the proper form
+            let task_comment = Regex::new(r"// http://rosettacode\.org/wiki/.+").unwrap();
+            if !task_comment.is_match(line) {
+                line_error(i + 1, path, "file does not start with \
+                           \"// http://rosettacode.org/wiki/<TASK NAME>\"");
+            }
+        }
+
         // Ignore '\r'
         if let Some('\r') = line.chars().rev().next() {
             line = &line[..line.len() - 1];
         }
-    
+
         // Check length
         if line.len() > 100 {
             line_error(i + 1, path, "line is longer than 100 characters");
         }
-        
+
         // Check trailing whitespace
         if let Some(last_char) = line.chars().rev().next() {
             if last_char.is_whitespace() {
                 line_error(i + 1, path, "line has trailing whitespace");
             }
         }
-        
     }
 }
 

--- a/coverage/Cargo.lock
+++ b/coverage/Cargo.lock
@@ -1,0 +1,389 @@
+[root]
+name = "coverage"
+version = "0.1.0"
+dependencies = [
+ "difference 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "docopt 0.6.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-rosetta 0.0.1",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "advapi32-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bitflags"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cookie"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "openssl 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "difference"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "docopt"
+version = "0.6.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "regex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "eventual"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syncbox 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gcc"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "advapi32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "hpack"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "httparse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "hyper"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cookie 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "httparse 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "language-tags 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solicit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "traitobject 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "language-tags"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lazy_static"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libc"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libressl-pnacl-sys"
+version = "2.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "pnacl-build-helper 1.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "log"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "matches"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memchr"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mime"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num_cpus"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "openssl"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gcc 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libressl-pnacl-sys 2.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "permutohedron"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "pnacl-build-helper"
+version = "1.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "advapi32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rust-rosetta"
+version = "0.0.1"
+dependencies = [
+ "eventual 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "permutohedron 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schedule_recv 0.0.1 (git+https://github.com/PeterReid/schedule_recv)",
+ "time 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rustc-serialize"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "schedule_recv"
+version = "0.0.1"
+source = "git+https://github.com/PeterReid/schedule_recv#d2c5a10d0a5b88788c139f6823eafb62e7c3aa03"
+dependencies = [
+ "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "solicit"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "hpack 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "strsim"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "syncbox"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tempdir"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "term"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "time"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "traitobject"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "typeable"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicase"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "url"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "walkdir"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+

--- a/coverage/Cargo.toml
+++ b/coverage/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+authors = ["Andy Russell <arussell123@gmail.com>"]
+name = "coverage"
+version = "0.1.0"
+
+[dependencies]
+difference = "0.4.1"
+docopt = "0.6.74"
+hyper = "0.6.15"
+regex = "0.1.41"
+rustc-serialize = "0.3.16"
+term = "0.2.12"
+url = "0.2.37"
+walkdir = "0.1.3"
+
+[dependencies.rust-rosetta]
+path = ".."
+version = "*"

--- a/coverage/src/main.rs
+++ b/coverage/src/main.rs
@@ -1,0 +1,159 @@
+extern crate difference;
+extern crate docopt;
+extern crate hyper;
+extern crate term;
+extern crate regex;
+extern crate rust_rosetta;
+extern crate rustc_serialize;
+extern crate walkdir;
+extern crate url;
+
+use rust_rosetta::rosetta_code::find_unimplemented_tasks::all_tasks;
+
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::prelude::*;
+use std::io::BufReader;
+use std::path::PathBuf;
+
+use docopt::Docopt;
+use difference::Difference;
+use hyper::Client;
+use hyper::header::Connection;
+use regex::Regex;
+use term::Terminal;
+use url::percent_encoding;
+use walkdir::WalkDir;
+
+const USAGE: &'static str = "
+Detect unimplemented tasks.
+
+This script prints out the name of each task, followed by whether it is implemented online,
+locally, or both.
+
+If no tasks are specified, determines the status for all tasks.
+
+Optionally prints out a diff as well.
+
+Usage:
+    coverage [options] [<tasks>...]
+
+Options:
+    -h --help       Show this screen.
+    --nodiff        Don't print diffs.
+";
+
+#[derive(Debug, RustcDecodable)]
+struct Args {
+    arg_tasks: Vec<String>,
+    flag_nodiff: bool,
+}
+
+// Normalizes a title according to MediaWiki's rules.
+//
+// TODO: This function is pretty fragile. A better solution would be to query the API with the URL
+// in the task, and then parse the normalized title from that.
+fn normalize(title: &str) -> String {
+    let title = title.replace(" ", "_");
+    let url_encoded_title =
+        percent_encoding::utf8_percent_encode(&title, percent_encoding::QUERY_ENCODE_SET);
+    url_encoded_title.replace("+", "%2B")
+}
+
+fn main() {
+    let args: Args = Docopt::new(USAGE)
+                        .and_then(|d| d.decode())
+                        .unwrap_or_else(|e| e.exit());
+
+    let mut t = term::stdout().unwrap();
+
+    let http_client = Client::new();
+
+    // Determine which tasks are implemented locally by walking the src folder and reading the
+    // comment at the top of the file.
+    let mut local_tasks: HashMap<String, PathBuf> = HashMap::new();
+    let task_comment = Regex::new("// http://rosettacode.org/wiki/(.+)").unwrap();
+    for entry in WalkDir::new("../src") {
+        let entry = entry.unwrap();
+        if entry.file_type().is_dir()
+            || entry.path().extension().map_or(false, |e| e != "rs")
+            || entry.path().file_name().map_or(false, |name| name == "lib.rs" || name == "mod.rs"){
+            continue
+        }
+
+        let file = File::open(entry.path()).unwrap();
+        let first_line = BufReader::new(file).lines().next().unwrap().unwrap();
+        let task_name = task_comment.captures(&first_line).and_then(|c| c.at(1)).unwrap();
+
+        local_tasks.insert(task_name.to_owned(), entry.path().to_owned());
+    }
+
+    let task_titles: Vec<String> = if args.arg_tasks.len() > 0 {
+        args.arg_tasks
+    } else {
+        all_tasks().iter().cloned().map(|t| t.title).collect()
+    };
+
+    // Extracts the code from the first <lang rust> tag
+    let rust_re = Regex::new(r"==\{\{header\|Rust\}\}==\s+<lang rust>((?s:.*?))</lang>").unwrap();
+
+    for title in task_titles {
+        let task_url = &format!("http://rosettacode.org/wiki/{}", normalize(&title));
+        t.attr(term::Attr::Bold).unwrap();
+        writeln!(t, "{}", title).unwrap();
+        t.reset().unwrap();
+
+        let local_code = local_tasks.get(&normalize(&title))
+            .and_then(|path| File::open(path).ok())
+            .and_then(|mut file| {
+                let mut local_code = String::new();
+                file.read_to_string(&mut local_code).unwrap();
+                Some(local_code)
+            });
+
+
+        let mut res = http_client.get(&format!("{}?{}", task_url, "action=raw"))
+            .header(Connection::close())
+            .send()
+            .unwrap();
+
+        let mut body = String::new();
+        res.read_to_string(&mut body).unwrap();
+        let online_code = rust_re.captures(&body)
+            .and_then(|captures| Some(captures.at(1).unwrap()));
+
+        writeln!(t, "Local: {}, Remote: {}", local_code.is_some(), online_code.is_some()).unwrap();
+
+        if !args.flag_nodiff && online_code.is_some() && local_code.is_some() {
+            let (_dist, changeset) =
+                difference::diff(&online_code.unwrap(), &local_code.unwrap(), "\n");
+
+            let mut t = term::stdout().unwrap();
+
+            for i in 0..changeset.len() {
+                match changeset[i] {
+                    Difference::Same(ref x) => {
+                        t.reset().unwrap();
+                        writeln!(t, " {}", x).unwrap();
+                    },
+                    Difference::Add(ref x) => {
+                        t.fg(term::color::GREEN).unwrap();
+                        for line in x.split("\n") {
+                            writeln!(t, "+{}", line).unwrap();
+                        }
+                    },
+                    Difference::Rem(ref x) => {
+                        t.fg(term::color::RED).unwrap();
+                        for line in x.split("\n") {
+                            writeln!(t, "-{}", line).unwrap();
+                        }
+                    }
+                }
+            }
+        }
+        t.reset().unwrap();
+        t.flush().unwrap();
+    }
+}
+
+

--- a/src/100_doors.rs
+++ b/src/100_doors.rs
@@ -1,6 +1,6 @@
+// http://rosettacode.org/wiki/100_doors
 extern crate num;
 
-// Implements http://rosettacode.org/wiki/100_doors
 use num::Float;
 use std::iter::Map;
 use std::ops::Range;

--- a/src/100_doors_unoptimized.rs
+++ b/src/100_doors_unoptimized.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/100_doors
+// http://rosettacode.org/wiki/100_doors
 // this is the unoptimized version that performs all 100
 // passes, as per the original description of the problem
 

--- a/src/2048.rs
+++ b/src/2048.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/2048
+// http://rosettacode.org/wiki/2048
 //
 // Based on the C++ version: http://rosettacode.org/wiki/2048#C.2B.2B
 // Uses rustbox (termbox) to draw the board.

--- a/src/24_game.rs
+++ b/src/24_game.rs
@@ -1,5 +1,5 @@
-// Implements http://rosettacode.org/wiki/24_game
-// with a recursive descent parser for a simple calculator (+ - * /)
+// http://rosettacode.org/wiki/24_game
+// Implements with a recursive descent parser for a simple calculator (+ - * /)
 // using the shunting yard algorithm as explained on
 // http://www.engr.mun.ca/~theo/Misc/exp_parsing.htm
 // It follows operator precedence (i.e. 2 + 3 * 3 = 11),

--- a/src/24_game_rpn.rs
+++ b/src/24_game_rpn.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/24_game
+// http://rosettacode.org/wiki/24_game
 // Uses RPN expression
 extern crate rand;
 

--- a/src/99_bottles_of_beer.rs
+++ b/src/99_bottles_of_beer.rs
@@ -1,6 +1,4 @@
-// Implements http://rosettacode.org/wiki/99_Bottles_of_Beer
-
-
+// http://rosettacode.org/wiki/99_Bottles_of_Beer
 use std::string::String;
 
 #[cfg(not(test))]

--- a/src/9_billion_names_of_god_the_integer.rs
+++ b/src/9_billion_names_of_god_the_integer.rs
@@ -1,4 +1,4 @@
-//Implements http://rosettacode.org/wiki/9_billion_names_of_God_the_integer
+// http://rosettacode.org/wiki/9_billion_names_of_God_the_integer
 
 extern crate num;
 

--- a/src/a_plus_b.rs
+++ b/src/a_plus_b.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/A%2BB
+// http://rosettacode.org/wiki/A%2BB
 use std::io;
 
 fn main() {

--- a/src/accumulator_factory.rs
+++ b/src/accumulator_factory.rs
@@ -1,3 +1,4 @@
+// http://rosettacode.org/wiki/Accumulator_factory
 use std::ops::Add;
 
 pub fn accum<'a, T>(mut n: T) -> Box<FnMut(T) -> T + 'a>

--- a/src/ackermann_function.rs
+++ b/src/ackermann_function.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Ackermann_function
+// http://rosettacode.org/wiki/Ackermann_function
 
 fn ack(m: isize, n: isize) -> isize {
     if m == 0 {

--- a/src/active_object.rs
+++ b/src/active_object.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Active_object
+// http://rosettacode.org/wiki/Active_object
 #![feature(mpsc_select)]
 
 extern crate time;

--- a/src/align_columns.rs
+++ b/src/align_columns.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Align_columns
+// http://rosettacode.org/wiki/Align_columns
 const TEST_STR: &'static str =
     "Given$a$text$file$of$many$lines,$where$fields$within$a$line$\nare$delineated\
     $by$a$single$'dollar'$character,$write$a$program\nthat$aligns$each$column$of\

--- a/src/almost_prime.rs
+++ b/src/almost_prime.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Almost_prime
+// http://rosettacode.org/wiki/Almost_prime
 fn is_kprime(mut n: usize, k: usize) -> bool {
     let mut p = 2;
     let mut f = 0;

--- a/src/anagrams.rs
+++ b/src/anagrams.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Anagrams
+// http://rosettacode.org/wiki/Anagrams
 #[cfg(not(test))] use std::fs::File;
 #[cfg(not(test))] use std::io::{BufReader, BufRead};
 use std::collections::{HashMap, HashSet};

--- a/src/arena_storage_pool.rs
+++ b/src/arena_storage_pool.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Arena_storage_pool
+// http://rosettacode.org/wiki/Arena_storage_pool
 #![feature(rustc_private)]
 
 extern crate arena;

--- a/src/arithmetic_integers.rs
+++ b/src/arithmetic_integers.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Arithmetic/Integer
+// http://rosettacode.org/wiki/Arithmetic/Integer
 #![cfg_attr(not(test), feature(slice_patterns))]
 use std::io::stdin;
 

--- a/src/arithmetic_mean.rs
+++ b/src/arithmetic_mean.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Averages/Arithmetic_mean
+// http://rosettacode.org/wiki/Averages/Arithmetic_mean
 
 // The mean is not defined for an empty list, so we must return an Option
 fn mean(list: &[f64]) -> Option<f64> {

--- a/src/arrays.rs
+++ b/src/arrays.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Arrays
+// http://rosettacode.org/wiki/Arrays
 
 #[cfg(not(test))]
 fn main() {}

--- a/src/assertions.rs
+++ b/src/assertions.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Assertions
+// http://rosettacode.org/wiki/Assertions
 
 fn main() {
     let my_number = 42;

--- a/src/atomic_updates.rs
+++ b/src/atomic_updates.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Atomic_updates
+// http://rosettacode.org/wiki/Atomic_updates
 //
 // This is mostly a straight port of the D version.  Originally, the "non-locking" Go solution was
 // tried, because it was supposed to be faster than the version with Mutexes, but my experience was

--- a/src/averages_mean_angle.rs
+++ b/src/averages_mean_angle.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Averages/Mean_angle
+// http://rosettacode.org/wiki/Averages/Mean_angle
 
 use std::f64::consts::PI;
 

--- a/src/balanced_brackets.rs
+++ b/src/balanced_brackets.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Balanced_brackets
+// http://rosettacode.org/wiki/Balanced_brackets
  // feature(rand) is used only in main
 
 

--- a/src/benford.rs
+++ b/src/benford.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Benford%27s_law
+// http://rosettacode.org/wiki/Benford%27s_law
 //
 // Contributed by Gavin Baker <gavinb@antonym.org>
 //

--- a/src/binary_digits.rs
+++ b/src/binary_digits.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Binary_digits
+// http://rosettacode.org/wiki/Binary_digits
 
 trait BinaryString {
     fn to_binary_string(&self) -> String;

--- a/src/bitmap.rs
+++ b/src/bitmap.rs
@@ -1,6 +1,4 @@
-// Implements http://rosettacode.org/wiki/Basic_bitmap_storage
-
-
+// http://rosettacode.org/wiki/Basic_bitmap_storage
 use std::default::Default;
 use std::io::{Write, BufWriter, Error};
 use std::fs::File;

--- a/src/bubble_sort.rs
+++ b/src/bubble_sort.rs
@@ -1,4 +1,4 @@
-//Implements http://rosettacode.org/wiki/Sorting_algorithms/Bubble_sort
+// http://rosettacode.org/wiki/Sorting_algorithms/Bubble_sort
 
 /// Progress through the slice and 'bubble' elements up until they are in order.
 fn bubble_sort<T: PartialOrd>(v: &mut [T]) {

--- a/src/call_an_object_method.rs
+++ b/src/call_an_object_method.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Call_an_object_method
+// http://rosettacode.org/wiki/Call_an_object_method
 
 struct Foo;
 

--- a/src/call_foreign_function.rs
+++ b/src/call_foreign_function.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Call_a_foreign-language_function
+// http://rosettacode.org/wiki/Call_a_foreign-language_function
 extern crate libc;
 
 use libc::c_char;

--- a/src/callback_to_array.rs
+++ b/src/callback_to_array.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Apply_a_callback_to_an_array
+// http://rosettacode.org/wiki/Apply_a_callback_to_an_array
 
 fn main () {
     let array = [1,2,3,4,5];

--- a/src/check_file.rs
+++ b/src/check_file.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Check_that_file_exists
+// http://rosettacode.org/wiki/Check_that_file_exists
 use std::path::Path;
 
 fn main() {

--- a/src/checkpoint_synchronization.rs
+++ b/src/checkpoint_synchronization.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Checkpoint_synchronization
+// http://rosettacode.org/wiki/Checkpoint_synchronization
 //
 // We implement this task using Rust's Barriers.  Barriers are simply thread
 // synchronization points--if a task waits at a barrier, it will not continue

--- a/src/closest-pair.rs
+++ b/src/closest-pair.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Closest-pair_problem
+// http://rosettacode.org/wiki/Closest-pair_problem
 
 // We interpret complex numbers as points in the Cartesian plane, here.
 // We also use the sweepline/plane sweep closest pairs algorithm

--- a/src/command_line_args.rs
+++ b/src/command_line_args.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Command-line_arguments
+// http://rosettacode.org/wiki/Command-line_arguments
 
 use std::env;
 

--- a/src/complex.rs
+++ b/src/complex.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Arithmetic/Complex
+// http://rosettacode.org/wiki/Arithmetic/Complex
 
 extern crate num;
 

--- a/src/concurrent_computing.rs
+++ b/src/concurrent_computing.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Concurrent_computing
+// http://rosettacode.org/wiki/Concurrent_computing
 extern crate rand;
 use std::thread::sleep_ms;
 use rand::random;

--- a/src/count_in_octal.rs
+++ b/src/count_in_octal.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Count_in_octal
+// http://rosettacode.org/wiki/Count_in_octal
 #![feature(range_inclusive)]
 
 use std::u8;

--- a/src/counting_sort.rs
+++ b/src/counting_sort.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Sorting_algorithms/Counting_sort
+// http://rosettacode.org/wiki/Sorting_algorithms/Counting_sort
 
 fn counting_sort(array: &mut [i32], min: i32, max: i32) {
 

--- a/src/create_file.rs
+++ b/src/create_file.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Create_a_file
+// http://rosettacode.org/wiki/Create_a_file
 use std::fs::{self, File};
 
 #[cfg(not(test))]

--- a/src/currying.rs
+++ b/src/currying.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Currying
+// http://rosettacode.org/wiki/Currying
 
 // add_n returns a a boxed unboxed closure.
 

--- a/src/dijkstras_algorithm.rs
+++ b/src/dijkstras_algorithm.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Dijkstra's_algorithm
+// http://rosettacode.org/wiki/Dijkstra's_algorithm
 
 use std::collections::{HashMap, BinaryHeap, LinkedList};
 use std::collections::hash_map::Entry::{Occupied, Vacant};

--- a/src/dns_query.rs
+++ b/src/dns_query.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/DNS_query
+// http://rosettacode.org/wiki/DNS_query
 #![feature(lookup_host)]
 use std::io;
 use std::net::{Ipv4Addr, Ipv6Addr};

--- a/src/dot_product.rs
+++ b/src/dot_product.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Dot_product
+// http://rosettacode.org/wiki/Dot_product
 extern crate num;
 
 use num::traits::Zero;

--- a/src/echo_server.rs
+++ b/src/echo_server.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Echo_server
+// http://rosettacode.org/wiki/Echo_server
 
 use std::io::{self, BufRead, BufReader, Write};
 use std::net::{TcpListener, TcpStream};

--- a/src/empty.rs
+++ b/src/empty.rs
@@ -1,3 +1,3 @@
-// Implements http://rosettacode.org/wiki/Empty_program
+// http://rosettacode.org/wiki/Empty_program
 
 fn main(){}

--- a/src/entropy.rs
+++ b/src/entropy.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Entropy
+// http://rosettacode.org/wiki/Entropy
 #![allow(unused_attributes)]
 #![allow(unused_features)]
 #![cfg_attr(test, feature(std_misc))]

--- a/src/enumerations.rs
+++ b/src/enumerations.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Enumerations
+// http://rosettacode.org/wiki/Enumerations
 
 #[allow(dead_code)]
 enum Fruits {

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Events
+// http://rosettacode.org/wiki/Events
 //
 // Rust uses condition variables (Condvars) for asynchronous event processing.  Each Mutex has a
 // list of zero or more Condvars, which are essentially events that the task may wait on or signal

--- a/src/factor_int.rs
+++ b/src/factor_int.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Factors_of_an_integer
+// http://rosettacode.org/wiki/Factors_of_an_integer
 
 #[cfg(not(test))]
 fn main() {

--- a/src/factorial.rs
+++ b/src/factorial.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Factorial
+// http://rosettacode.org/wiki/Factorial
 #![cfg_attr(test, feature(test))]
 
 // Calculate the factorial using recursion

--- a/src/factorial_plugin.rs
+++ b/src/factorial_plugin.rs
@@ -1,3 +1,4 @@
+// http://rosettacode.org/wiki/Factorial
 #![crate_type="dylib"]
 #![feature(plugin_registrar)]
 #![feature(rustc_private)]

--- a/src/fast_fourier_transform.rs
+++ b/src/fast_fourier_transform.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Fast_Fourier_transform
+// http://rosettacode.org/wiki/Fast_Fourier_transform
 extern crate num;
 
 use std::f32::consts::PI;

--- a/src/fibonacci.rs
+++ b/src/fibonacci.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Fibonacci_sequence
+// http://rosettacode.org/wiki/Fibonacci_sequence
 
 #[cfg(not(test))]
 fn main() {

--- a/src/fibonacci_word.rs
+++ b/src/fibonacci_word.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Fibonacci_word
+// http://rosettacode.org/wiki/Fibonacci_word
 use entropy::shannon_entropy;
 mod entropy;
 

--- a/src/filesize.rs
+++ b/src/filesize.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/File_size
+// http://rosettacode.org/wiki/File_size
 use std::fs;
 fn main() {
     if let Ok(attr) = fs::metadata("input.txt") {

--- a/src/flatten_list.rs
+++ b/src/flatten_list.rs
@@ -1,4 +1,4 @@
-//http://rosettacode.org/wiki/Flatten_a_list
+// http://rosettacode.org/wiki/Flatten_a_list
 
 #![feature(box_syntax)]
 use Tree::{Node, Leaf};

--- a/src/four_bit_adder.rs
+++ b/src/four_bit_adder.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Four_bit_adder
+// http://rosettacode.org/wiki/Four_bit_adder
 use std::ops::Deref;
 use std::fmt;
 

--- a/src/function_def.rs
+++ b/src/function_def.rs
@@ -1,4 +1,4 @@
-//http://rosettacode.org/wiki/Function_definition
+// http://rosettacode.org/wiki/Function_definition
 use std::ops::Mul;
 
 // Function taking 2 ints, multply them and return the value

--- a/src/gray_code.rs
+++ b/src/gray_code.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Gray_code
+// http://rosettacode.org/wiki/Gray_code
 // Encode an usize
 fn gray_encode(integer: usize) -> usize {
     (integer >> 1) ^ integer

--- a/src/guess_number.rs
+++ b/src/guess_number.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Guess_the_number
+// http://rosettacode.org/wiki/Guess_the_number
 extern crate rand;
 use rand::{thread_rng, Rng};
 use std::io::stdin;

--- a/src/hailstone.rs
+++ b/src/hailstone.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Hailstone_sequence
+// http://rosettacode.org/wiki/Hailstone_sequence
 // Define a struct which stores the state for the iterator.
 #![feature(iter_cmp)]
 

--- a/src/hamming_numbers_alt.rs
+++ b/src/hamming_numbers_alt.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Hamming_numbers
+// http://rosettacode.org/wiki/Hamming_numbers
 // alternate version: uses a more efficient representation of Hamming numbers:
 // instead of storing them as BigUint directly, it stores the three exponents
 // i, j and k for 2^i * 3^j * 5 ^k and the logarithm of the number for comparisons

--- a/src/handle_a_signal.rs
+++ b/src/handle_a_signal.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Handle_a_signal
+// http://rosettacode.org/wiki/Handle_a_signal
 //
 // Note that this solution only works on Unix.
 #![cfg_attr(unix, feature(std_misc))]

--- a/src/happy_numbers.rs
+++ b/src/happy_numbers.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Happy_numbers
+// http://rosettacode.org/wiki/Happy_numbers
 fn digits(mut n: usize) -> Vec<usize> {
     let mut ds = vec![];
     if n == 0 {

--- a/src/heap_sort.rs
+++ b/src/heap_sort.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Sorting_algorithms/Heapsort
+// http://rosettacode.org/wiki/Sorting_algorithms/Heapsort
 
 // This is ported from the Dart heap sort implementation
 fn heap_sort<T: Ord>(a: &mut [T]) {

--- a/src/higher_order_functions.rs
+++ b/src/higher_order_functions.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Higher-order_functions
+// http://rosettacode.org/wiki/Higher-order_functions
 fn plain_function() {
     println!("regular function");
 }

--- a/src/hofstadter_q.rs
+++ b/src/hofstadter_q.rs
@@ -1,4 +1,5 @@
-// Implements an iterable version of http://rosettacode.org/wiki/Hofstadter_Q_sequence
+// http://rosettacode.org/wiki/Hofstadter_Q_sequence
+// An iterable version.
 
 // Define a struct which stores the state for the iterator.
 struct HofstadterQ {

--- a/src/host_introspection.rs
+++ b/src/host_introspection.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Host_introspection
+// http://rosettacode.org/wiki/Host_introspection
 
 fn main() {
     println!("word size: {} bits", 8 * std::mem::size_of::<usize>());

--- a/src/hough_transform.rs
+++ b/src/hough_transform.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Hough_transform
+// http://rosettacode.org/wiki/Hough_transform
 //
 // Contributed by Gavin Baker <gavinb@antonym.org>
 // Adapted from the Go version

--- a/src/huffman_coding.rs
+++ b/src/huffman_coding.rs
@@ -1,6 +1,5 @@
-
+// http://rosettacode.org/wiki/Huffman_coding
 // Implement data structures for a Huffman encoding tree:
-//   http://rosettacode.org/wiki/Huffman_coding
 use std::collections::HashMap;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::BinaryHeap;

--- a/src/iban.rs
+++ b/src/iban.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/IBAN
+// http://rosettacode.org/wiki/IBAN
 extern crate num;
 
 use num::bigint::{BigInt, ToBigInt};

--- a/src/infinity.rs
+++ b/src/infinity.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Infinity
+// http://rosettacode.org/wiki/Infinity
 
 fn main() {
     let inf = ::std::f32::INFINITY;

--- a/src/input_is_terminal.rs
+++ b/src/input_is_terminal.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Check_input_device_is_a_terminal
+// http://rosettacode.org/wiki/Check_input_device_is_a_terminal
 extern crate libc;
 
 fn main() {

--- a/src/input_loop.rs
+++ b/src/input_loop.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Input_loop
+// http://rosettacode.org/wiki/Input_loop
 use std::io::{self, BufRead};
 
 fn main() {

--- a/src/integer_sequence.rs
+++ b/src/integer_sequence.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Integer_sequence
+// http://rosettacode.org/wiki/Integer_sequence
 
 extern crate num;
 

--- a/src/josephus_problem.rs
+++ b/src/josephus_problem.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Josephus_problem
+// http://rosettacode.org/wiki/Josephus_problem
 
 
 // implementation based on observation:

--- a/src/json.rs
+++ b/src/json.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/JSON
+// http://rosettacode.org/wiki/JSON
 extern crate rustc_serialize;
 use rustc_serialize::json;
 

--- a/src/k-d-tree.rs
+++ b/src/k-d-tree.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/K-d_tree
+// http://rosettacode.org/wiki/K-d_tree
 
 extern crate time;
 extern crate rand;

--- a/src/kahansum.rs
+++ b/src/kahansum.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Kahan_summation
+// http://rosettacode.org/wiki/Kahan_summation
 extern crate num;
 extern crate permutohedron;
 

--- a/src/letter_frequency.rs
+++ b/src/letter_frequency.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Letter_frequency
+// http://rosettacode.org/wiki/Letter_frequency
 #![cfg_attr(not(test), feature(io))]
 
 #[cfg(not(test))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,10 @@
 // Dummy main library
 // It also contains a test module, which checks if all source files are covered by `Cargo.toml`
+extern crate hyper;
 extern crate regex;
+extern crate rustc_serialize;
+
+pub mod rosetta_code;
 
 #[allow(dead_code)]
 fn main() { }

--- a/src/linear_congruential_generator.rs
+++ b/src/linear_congruential_generator.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Linear_congruential_generator
+// http://rosettacode.org/wiki/Linear_congruential_generator
 use std::num::Wrapping as w;
 
 trait LinearCongruentialGenerator {

--- a/src/longest_common_subsequence.rs
+++ b/src/longest_common_subsequence.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Longest_common_subsequence
+// http://rosettacode.org/wiki/Longest_common_subsequence
 
 /// Returns the longest common subsequence of a and b.
 fn longest_common_subsequence(a: &str, b: &str) -> String {

--- a/src/loops-for.rs
+++ b/src/loops-for.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Loops/For
+// http://rosettacode.org/wiki/Loops/For
 
 fn main() {
     for i in (1..6) {

--- a/src/loops-foreach.rs
+++ b/src/loops-foreach.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Loops/For
+// http://rosettacode.org/wiki/Loops/For
 
 use std::collections::HashMap;
 

--- a/src/loops-infinite.rs
+++ b/src/loops-infinite.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Loops/Infinite
+// http://rosettacode.org/wiki/Loops/Infinite
 
 fn main() {
     loop {

--- a/src/loops-n-plus-one-half.rs
+++ b/src/loops-n-plus-one-half.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Loops/N_plus_one_half
+// http://rosettacode.org/wiki/Loops/N_plus_one_half
 
 
 fn main() {

--- a/src/loops-while.rs
+++ b/src/loops-while.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Loops/While
+// http://rosettacode.org/wiki/Loops/While
 
 fn main() {
     let mut i = 1024;

--- a/src/luhn_test.rs
+++ b/src/luhn_test.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Luhn_test_of_credit_card_numbers
+// http://rosettacode.org/wiki/Luhn_test_of_credit_card_numbers
 struct Digits {
     m: u64
 }

--- a/src/lzw.rs
+++ b/src/lzw.rs
@@ -1,7 +1,4 @@
-// Implements http://rosettacode.org/wiki/LZW_compression
-
-
-
+// http://rosettacode.org/wiki/LZW_compression
 use std::collections::hash_map::HashMap;
 
 // Compress using LZW

--- a/src/markov_algorithm.rs
+++ b/src/markov_algorithm.rs
@@ -1,4 +1,4 @@
-// Solution for http://rosettacode.org/wiki/Execute_a_Markov_algorithm
+// http://rosettacode.org/wiki/Execute_a_Markov_algorithm
 
 #![feature(str_char)]
 // Individual markov rule

--- a/src/md5-implementation.rs
+++ b/src/md5-implementation.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/MD5/Implementation
+// http://rosettacode.org/wiki/MD5/Implementation
 /*
  * Ported from C - Simple MD5 implementation
 * on Wikipedia https://en.wikipedia.org/wiki/MD5

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Menu
+// http://rosettacode.org/wiki/Menu
 use std::io;
 // Print the menu followed by the prompt
 fn print_both(menu: &[&str], prompt: &str) {

--- a/src/merge-sort.rs
+++ b/src/merge-sort.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Sorting_algorithms/Merge_sort
+// http://rosettacode.org/wiki/Sorting_algorithms/Merge_sort
 
 // This is an idiomatic-but-slow implementation. A more efficient implementation
 // would use `unsafe` to avoid allocating so many temporary vectors.

--- a/src/metered_concurrency.rs
+++ b/src/metered_concurrency.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Metered_concurrency
+// http://rosettacode.org/wiki/Metered_concurrency
 // Rust has a perfectly good Semaphore type already.  It lacks count(), though, so we can't use it
 // directly.
 

--- a/src/mutual_recursion.rs
+++ b/src/mutual_recursion.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Mutual_recursion
+// http://rosettacode.org/wiki/Mutual_recursion
 
 
 fn f(n: usize) -> usize {

--- a/src/n_queens.rs
+++ b/src/n_queens.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/N-queens_problem
+// http://rosettacode.org/wiki/N-queens_problem
 #![feature(test)]
 
 extern crate test;

--- a/src/output_is_terminal.rs
+++ b/src/output_is_terminal.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Check_output_device_is_a_terminal
+// http://rosettacode.org/wiki/Check_output_device_is_a_terminal
 extern crate libc;
 
 fn main() {

--- a/src/palindrome.rs
+++ b/src/palindrome.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Palindrome_detection
+// http://rosettacode.org/wiki/Palindrome_detection
 
 
 // Returns true if the string is a palindrome

--- a/src/pangram.rs
+++ b/src/pangram.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Pangram_checker
+// http://rosettacode.org/wiki/Pangram_checker
 use std::collections::HashSet;
 
 // Returns true if the sentence uses all 26 letters in the English

--- a/src/parallel_calculations.rs
+++ b/src/parallel_calculations.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Parallel_calculations
+// http://rosettacode.org/wiki/Parallel_calculations
 // See http://static.rust-lang.org/doc/master/guide-tasks.html for information
 // about tasks, channels, future, etc.
 #![cfg_attr(test, feature(test))]

--- a/src/pascals_triangle.rs
+++ b/src/pascals_triangle.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Pascal%27s_triangle
+// http://rosettacode.org/wiki/Pascal%27s_triangle
 
 fn pascaltriangle(rows: usize) -> Vec<Vec<usize>> {
     let mut all_rows = Vec::with_capacity(rows);

--- a/src/perfect_numbers.rs
+++ b/src/perfect_numbers.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Perfect_numbers
+// http://rosettacode.org/wiki/Perfect_numbers
 fn perfect_number(n: usize) -> bool {
   (1..(n / 2)+1).filter(|&i| n % i == 0).fold(0,|a, b| a + b) == n
 }

--- a/src/permutations_with_repetitions.rs
+++ b/src/permutations_with_repetitions.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Permutations_with_repetitions
+// http://rosettacode.org/wiki/Permutations_with_repetitions
 
 struct PermutationIterator<'a, T: 'a> {
     universe: &'a [T],

--- a/src/power_set.rs
+++ b/src/power_set.rs
@@ -1,5 +1,5 @@
-// Given a set, generate its power set, which is the set of all subsets of that
-// set: http://rosettacode.org/wiki/Power_set
+// http://rosettacode.org/wiki/Power_set
+// Given a set, generate its power set, which is the set of all subsets of that set.
 
 use std::vec::Vec;
 use std::slice::Iter;

--- a/src/primality_trial_div.rs
+++ b/src/primality_trial_div.rs
@@ -1,4 +1,4 @@
-//Implements http://rosettacode.org/wiki/Primality_by_Trial_Division
+// http://rosettacode.org/wiki/Primality_by_Trial_Division
 #![feature(step_by)]
 
 fn is_prime(number: i32) -> bool {

--- a/src/prime_decomposition.rs
+++ b/src/prime_decomposition.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Prime_decomposition
+// http://rosettacode.org/wiki/Prime_decomposition
 
 // We need this to be public because it is used from another file
 pub fn factor(mut nb: usize) -> Vec<usize> {

--- a/src/proper_divisors.rs
+++ b/src/proper_divisors.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Proper_divisors
+// http://rosettacode.org/wiki/Proper_divisors
 
 // Populate input vector with prime numbers < maxvalue
 fn add_more_prime_numbers(v:&mut Vec<usize>,maxvalue:usize) {

--- a/src/quick_sort.rs
+++ b/src/quick_sort.rs
@@ -1,4 +1,4 @@
-//Implements http://rosettacode.org/wiki/Sorting_algorithms/Quicksort
+// http://rosettacode.org/wiki/Sorting_algorithms/Quicksort
 // Used by the tests
 
 

--- a/src/range_expansion.rs
+++ b/src/range_expansion.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Range_expansion
+// http://rosettacode.org/wiki/Range_expansion
 extern crate regex;
 
 #[cfg(not(test))]

--- a/src/read_file_line.rs
+++ b/src/read_file_line.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Read_a_file_line_by_line
+// http://rosettacode.org/wiki/Read_a_file_line_by_line
 use std::fs::File;
 use std::io::{BufReader, BufRead};
 use std::env::args;

--- a/src/read_file_specific_line.rs
+++ b/src/read_file_specific_line.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Read_a_specific_line_from_a_file
+// http://rosettacode.org/wiki/Read_a_specific_line_from_a_file
 use std::fs::File;
 use std::io::{BufReader, BufRead};
 use std::env::args;

--- a/src/recursion_depth.rs
+++ b/src/recursion_depth.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Find_limit_of_recursion
+// http://rosettacode.org/wiki/Find_limit_of_recursion
 #[allow(unconditional_recursion)]
 
 fn recursion(n: i32) {

--- a/src/rename_a_file.rs
+++ b/src/rename_a_file.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Rename_a_file
+// http://rosettacode.org/wiki/Rename_a_file
 use std::fs;
 
 fn main() {

--- a/src/reverse_words_str.rs
+++ b/src/reverse_words_str.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Reverse_words_in_a_string
+// http://rosettacode.org/wiki/Reverse_words_in_a_string
 
 fn rev_words(line: &str) -> String {
     line.split_whitespace().rev().collect::<Vec<&str>>().join(" ")

--- a/src/rock_paper_scissors.rs
+++ b/src/rock_paper_scissors.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Rock-paper-scissors
+// http://rosettacode.org/wiki/Rock-paper-scissors
 // Unfortunately, this won't compile without Cargo, due to the "rand"
 // crate conflict, so it should be noted on rosettacode task page.
 

--- a/src/rosetta_code/find_unimplemented_tasks.rs
+++ b/src/rosetta_code/find_unimplemented_tasks.rs
@@ -1,0 +1,112 @@
+// http://rosettacode.org/wiki/Rosetta_Code/Find_unimplemented_tasks
+extern crate hyper;
+extern crate rustc_serialize;
+
+use std::collections::HashSet;
+use std::io::prelude::*;
+
+use hyper::Client;
+use hyper::header::Connection;
+use rustc_serialize::json::Json;
+
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+struct Task {
+    id: String,
+    title: String,
+}
+
+struct Category {
+    name: String,
+    cmcontinue: Option<String>,
+    http_client: Client,
+    is_first_iteration: bool,
+}
+
+impl Category {
+    fn new(name: &str) -> Category {
+        Category {
+            name: name.to_owned(),
+            cmcontinue: None,
+            http_client: Client::new(),
+            is_first_iteration: true,
+        }
+    }
+}
+
+impl Iterator for Category {
+    type Item = Vec<Task>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.cmcontinue.is_none() && !self.is_first_iteration {
+            return None
+        }
+
+        self.is_first_iteration = false;
+
+        let cmcontinue = match self.cmcontinue {
+            Some(ref cmcontinue) => format!("&cmcontinue={}", cmcontinue),
+            None => "".to_owned()
+        };
+
+        let url = &format!("http://rosettacode.org/mw/api.php?\
+            action=query&\
+            list=categorymembers&\
+            cmtitle=Category:{}&\
+            cmlimit=500&format=json{}", self.name, cmcontinue);
+
+        let mut res = self.http_client.get(url)
+            .header(Connection::close())
+            .send()
+            .unwrap();
+
+        let mut body = String::new();
+        res.read_to_string(&mut body).unwrap();
+
+        let json = Json::from_str(&body).unwrap();
+        let tasks = json.as_object().unwrap()
+                        .get("query").unwrap().as_object().unwrap()
+                        .get("categorymembers").unwrap().as_array().unwrap()
+                        .iter()
+                        .map(|cm| {
+                            let cm_obj = cm.as_object().unwrap();
+                            Task {
+                                id: cm_obj.get("pageid").unwrap().as_u64().unwrap()
+                                        .to_string(),
+                                title: cm_obj.get("title").unwrap().as_string().unwrap()
+                                        .to_owned(),
+                            }
+                        })
+                        .collect::<Vec<_>>();
+
+        self.cmcontinue = json.as_object().unwrap()
+                          .get("query-continue")
+                          .map(|query_continue| {
+                              query_continue.as_object().unwrap()
+                                  .get("categorymembers").unwrap().as_object().unwrap()
+                                  .get("cmcontinue").unwrap().as_string().unwrap()
+                                  .to_owned()
+                          });
+
+        Some(tasks)
+    }
+}
+
+fn unimplemented_tasks(lang: &str) -> Vec<Task> {
+    let all_tasks = Category::new("Programming Tasks")
+        .flat_map(|tasks| tasks)
+        .collect::<HashSet<_>>();
+    let implemented_tasks = Category::new(lang)
+        .flat_map(|tasks| tasks)
+        .collect::<HashSet<_>>();
+    let mut unimplemented_tasks = all_tasks.difference(&implemented_tasks)
+        .cloned()
+        .collect::<Vec<Task>>();
+    unimplemented_tasks.sort_by(|a, b| a.title.cmp(&b.title));
+    unimplemented_tasks
+}
+
+pub fn main() {
+    for task in unimplemented_tasks("Rust") {
+        println!("{:6} {}", task.id, task.title);
+    }
+}

--- a/src/rosetta_code/find_unimplemented_tasks.rs
+++ b/src/rosetta_code/find_unimplemented_tasks.rs
@@ -10,9 +10,9 @@ use hyper::header::Connection;
 use rustc_serialize::json::Json;
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
-struct Task {
-    id: String,
-    title: String,
+pub struct Task {
+    pub id: String,
+    pub title: String,
 }
 
 struct Category {
@@ -91,10 +91,14 @@ impl Iterator for Category {
     }
 }
 
-fn unimplemented_tasks(lang: &str) -> Vec<Task> {
-    let all_tasks = Category::new("Programming Tasks")
+pub fn all_tasks() -> Vec<Task> {
+    Category::new("Programming Tasks")
         .flat_map(|tasks| tasks)
-        .collect::<HashSet<_>>();
+        .collect()
+}
+
+pub fn unimplemented_tasks(lang: &str) -> Vec<Task> {
+    let all_tasks = all_tasks().iter().cloned().collect::<HashSet<_>>();
     let implemented_tasks = Category::new(lang)
         .flat_map(|tasks| tasks)
         .collect::<HashSet<_>>();

--- a/src/rosetta_code/mod.rs
+++ b/src/rosetta_code/mod.rs
@@ -1,0 +1,1 @@
+pub mod find_unimplemented_tasks;

--- a/src/rot13.rs
+++ b/src/rot13.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Rot-13
+// http://rosettacode.org/wiki/Rot-13
 
 fn rot13 (string: &str) -> String {
     fn rot13u8 (c: char) -> char {

--- a/src/rsa_code.rs
+++ b/src/rsa_code.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/RSA_code
+// http://rosettacode.org/wiki/RSA_code
 extern crate num;
 
 use num::bigint::BigUint;

--- a/src/s_expressions.rs
+++ b/src/s_expressions.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/S-Expressions
+// http://rosettacode.org/wiki/S-Expressions
 //
 // This implementation isn't based on anything in particular, although it's probably informed by a
 // lot of Rust's JSON encoding code.  It should be very fast (both encoding and decoding the toy

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Set
+// http://rosettacode.org/wiki/Set
 
 use std::collections::HashSet;
 

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -1,6 +1,5 @@
-// Implements http://rosettacode.org/wiki/SHA-1
-// straight port from golang crypto/sha1
-// library implementation
+// http://rosettacode.org/wiki/SHA-1
+// Straight port from golang crypto/sha1 library implementation
 #![feature(slice_bytes)]
 
 use std::num::Wrapping as wr;

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/SHA-256
+// http://rosettacode.org/wiki/SHA-256
 
 #![feature(rustc_private)]
 

--- a/src/short_circuit_evaluation.rs
+++ b/src/short_circuit_evaluation.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Short-circuit_evaluation
+// http://rosettacode.org/wiki/Short-circuit_evaluation
 
 fn a(x: bool) -> bool {
     println!("Inside function a");

--- a/src/sieve_eratosthenes.rs
+++ b/src/sieve_eratosthenes.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Sieve_of_Eratosthenes
+// http://rosettacode.org/wiki/Sieve_of_Eratosthenes
 #![feature(step_by)]
 
 use std::iter::repeat;

--- a/src/sort_int.rs
+++ b/src/sort_int.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Sort_an_integer_array
+// http://rosettacode.org/wiki/Sort_an_integer_array
 
 #[cfg(not(test))]
 fn main() {

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Stack
+// http://rosettacode.org/wiki/Stack
 #[derive(Debug)]
 struct Stack<T> {
     // We use a vector because of simplicity

--- a/src/stderr.rs
+++ b/src/stderr.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Hello_world/Standard_error
+// http://rosettacode.org/wiki/Hello_world/Standard_error
 use std::io::{self, Write};
 
 fn main() {

--- a/src/stdev.rs
+++ b/src/stdev.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Standard_deviation
+// http://rosettacode.org/wiki/Standard_deviation
 struct StDev {
     len: usize,
     sum: f32,

--- a/src/string_interpolation.rs
+++ b/src/string_interpolation.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/String_interpolation
+// http://rosettacode.org/wiki/String_interpolation
 
 #[cfg(not(test))]
 fn main() {

--- a/src/string_is_numeric.rs
+++ b/src/string_is_numeric.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Determine_if_a_string_is_numeric
+// http://rosettacode.org/wiki/Determine_if_a_string_is_numeric
 
 fn is_numeric (s: &str) -> bool {
 	s.parse::<f64>().is_ok()

--- a/src/string_matching.rs
+++ b/src/string_matching.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/String_matching
+// http://rosettacode.org/wiki/String_matching
 
 fn match_string(container: &str, target: &str) -> (bool, bool, bool) {
   let starts = container.starts_with(target);

--- a/src/sum_digits.rs
+++ b/src/sum_digits.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Sum_digits_of_an_integer
+// http://rosettacode.org/wiki/Sum_digits_of_an_integer
 
 
 fn sum(n: usize, base: usize) -> usize {

--- a/src/swap.rs
+++ b/src/swap.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Generic_swap
+// http://rosettacode.org/wiki/Generic_swap
 use std::mem::swap;
 
 fn main() {

--- a/src/tic_tac_toe.rs
+++ b/src/tic_tac_toe.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Tic-tac-toe
+// http://rosettacode.org/wiki/Tic-tac-toe
 extern crate rand;
 
 use GameState::{PlayerWin, ComputerWin, Draw, Playing};

--- a/src/unix_ls.rs
+++ b/src/unix_ls.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Unix/ls#Rust
+// http://rosettacode.org/wiki/Unix/ls#Rust
 // Works only with correct paths or no arguments at all
 
 use std::env;

--- a/src/vigenere.rs
+++ b/src/vigenere.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Vigen%C3%A8re_cipher
+// http://rosettacode.org/wiki/Vigen%C3%A8re_cipher
 use std::ascii::AsciiExt;
 
 const ASCII_A: u8 = 'A' as u8;

--- a/src/walk_recursive.rs
+++ b/src/walk_recursive.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Walk_a_directory/Recursively
+// http://rosettacode.org/wiki/Walk_a_directory/Recursively
 extern crate regex;
 
 use regex::Regex;

--- a/src/webserver.rs
+++ b/src/webserver.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Hello_world/Web_server
+// http://rosettacode.org/wiki/Hello_world/Web_server
 use std::net::{TcpStream, TcpListener, Shutdown};
 use std::io::{Write, Result};
 #[cfg(not(test))] use std::borrow::ToOwned;

--- a/src/wireworld.rs
+++ b/src/wireworld.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Wireworld
+// http://rosettacode.org/wiki/Wireworld
 
 use std::mem;
 

--- a/src/write_ppm.rs
+++ b/src/write_ppm.rs
@@ -1,4 +1,4 @@
-// Implements http://rosettacode.org/wiki/Write_ppm_file
+// http://rosettacode.org/wiki/Write_ppm_file
 extern crate rand;
 
 use std::fs::File;

--- a/src/zig-zag_matrix.rs
+++ b/src/zig-zag_matrix.rs
@@ -1,5 +1,5 @@
-// implements http://rosettacode.org/wiki/Zig-zag_matrix
-// with the sorting indexes algorithm
+// http://rosettacode.org/wiki/Zig-zag_matrix
+// Implements with the sorting indexes algorithm
 // explained in the discussion page
 // http://rosettacode.org/wiki/Talk:Zig-zag_matrix
 use std::iter::repeat;


### PR DESCRIPTION
Work towards #402.

Here's an initial implementation of a subcrate `coverage` that allows users to print out diffs of the Rosetta code implementations online as opposed to the ones on their local machine.

It's not the cleanest, but I think it's ready for some code review at least. And I'd definitely like to get some input on the UI, names, etc.

Of note: I made it a hard build requirement for implementations to start with the URL, as stated in the README. This vastly simplifies tying tasks to their online counterparts.

I also think that we should start grouping related tasks under their own modules. I created a `rosetta_code` module with this.