### PR TITLE
Fix warnings

### DIFF
--- a/src/24_game.rs
+++ b/src/24_game.rs
@@ -18,7 +18,7 @@ fn main() {
     use std::io;
 
     let mut rng = rand::thread_rng();
-    let mut input = io::stdin();
+    let input = io::stdin();
 
     loop {
         let mut sample = rand::sample(&mut rng, (1u32..10), 4);

--- a/src/24_game_rpn.rs
+++ b/src/24_game_rpn.rs
@@ -8,7 +8,7 @@ fn main() {
     use std::io::{self, Write};
 
     let mut rng = rand::thread_rng();
-    let mut stdin = io::stdin();
+    let stdin = io::stdin();
     let mut stdout = io::stdout();
 
     // generating 4 numbers

--- a/src/9_billion_names_of_god_the_integer.rs
+++ b/src/9_billion_names_of_god_the_integer.rs
@@ -35,10 +35,10 @@ impl Solver {
     }
 
     fn cumulative(&mut self, idx: usize) -> &[BigUint] {
-        for l in (self.cache.len()..idx+1) {
+        for l in self.cache.len()..idx + 1 {
             let mut r : Vec<BigUint> = vec![Zero::zero()];
 
-            for x in (1..l+1) {
+            for x in 1..l + 1 {
                 let w = {
                     let y = &r[x-1];
                     let z = &self.cache[l-x][min(x, l-x)];

--- a/src/active_object.rs
+++ b/src/active_object.rs
@@ -1,7 +1,6 @@
 // http://rosettacode.org/wiki/Active_object
 #![feature(mpsc_select)]
 
-extern crate time;
 extern crate num;
 extern crate schedule_recv;
 
@@ -9,8 +8,8 @@ use num::traits::Zero;
 use num::Float;
 use std::f64::consts::PI;
 use std::sync::{Arc, Mutex};
-use time::Duration;
 use std::thread::{self, spawn};
+use std::time::Duration;
 use std::sync::mpsc::{channel, Sender, SendError};
 use std::ops::Mul;
 use schedule_recv::periodic_ms;
@@ -132,12 +131,13 @@ impl<S: Mul<f64, Output=T> + Float + Zero,
 fn integrate() -> f64 {
     let object = Integrator::new(10);
     object.input(Box::new(|t: u32| {
-        let f = 1. / Duration::seconds(2).num_milliseconds() as f64;
+        let two_seconds_ms = 2 * 1000;
+        let f = 1. / two_seconds_ms as f64;
         (2. * PI * f * t as f64).sin()
     })).ok().expect("Failed to set input");
-    thread::sleep_ms(2000);
+    thread::sleep(Duration::from_secs(2));
     object.input(Box::new(|_| 0.)).ok().expect("Failed to set input");
-    thread::sleep_ms(500);
+    thread::sleep(Duration::from_millis(500));
     object.output()
 }
 
@@ -154,11 +154,12 @@ fn solution() {
     // FIXME(pythonesque): When unboxed closures are fixed, fix integrate() to take two arguments.
     let object = Integrator::new(10);
     object.input(Box::new(|t: u32| {
-        let f = 1. / (Duration::seconds(2) / 10).num_milliseconds() as f64;
+        let two_seconds_ms = 2 * 1000;
+        let f = 1. / (two_seconds_ms / 10) as f64;
         (2. * PI * f * t as f64).sin()
     })).ok().expect("Failed to set input");
-    thread::sleep_ms(200);
+    thread::sleep(Duration::from_millis(200));
     object.input(Box::new(|_| 0.)).ok().expect("Failed to set input");
-    thread::sleep_ms(100);
+    thread::sleep(Duration::from_millis(100));
     assert_eq!(object.output() as u32, 0)
 }

--- a/src/arithmetic_rational.rs
+++ b/src/arithmetic_rational.rs
@@ -15,11 +15,11 @@ fn main() {
 
 fn perfect_numbers(max: i64) -> Vec<i64> {
     let mut ret=Vec::new();
-    for candidate in (2..max) {
+    for candidate in 2..max {
         let mut sum=Frac::secure_new(1, candidate).unwrap();
         let max2=((candidate as f64).sqrt().floor()) as i64;
 
-        for factor in (2..max2+1) {
+        for factor in 2..max2 + 1 {
             if candidate % factor == 0 {
                 sum = sum + Frac::new(1, factor) + Frac::new(factor, candidate);
             }

--- a/src/benford.rs
+++ b/src/benford.rs
@@ -48,7 +48,7 @@ fn benford_distrib(numbers: &[u64]) -> Vec<f32> {
 fn main() {
     // Calculate expected frequencies of all digits according to Benford's Law
     let mut expected_distrib = [0f32; 10];
-    for digit in (1..10) {
+    for digit in 1..10 {
         expected_distrib[digit] = benford_freq(digit as u64);
     }
 
@@ -70,7 +70,7 @@ fn main() {
     println!("\nBenford's Law - Digit Distribution");
     println!("\nFirst 1000 Numbers in the Fibonacci Sequence\n");
     println!("digit    expect     found     delta");
-    for digit in (1..10) {
+    for digit in 1..10 {
         let expected_pc = expected_distrib[digit] * 100.0;
         let found_pc = found_distrib[digit] * 100.0;
         let delta_pc = expected_pc - found_pc;

--- a/src/binary_digits.rs
+++ b/src/binary_digits.rs
@@ -12,7 +12,7 @@ impl BinaryString for usize {
 
 #[cfg(not(test))]
 fn main() {
-    for s in (0..17) {
+    for s in 0..17 {
         println!("{}", s.to_binary_string());
     }
 }

--- a/src/bubble_sort.rs
+++ b/src/bubble_sort.rs
@@ -5,7 +5,7 @@ fn bubble_sort<T: PartialOrd>(v: &mut [T]) {
     (1..v.len()+1).rev().all(|length| {
         let mut changes = 0;
 
-        for index in (0..length - 1) {
+        for index in 0..length - 1 {
             if v[index] > v[index + 1] {
                 changes += 1;
                 v.swap(index, index + 1);

--- a/src/bulls_and_cows.rs
+++ b/src/bulls_and_cows.rs
@@ -78,7 +78,7 @@ fn calculate_score(given_digits: &[u32], guessed_digits: &[u32]) ->
 
 #[cfg(not(test))]
 fn main() {
-    let mut reader = std::io::stdin();
+    let reader = std::io::stdin();
     loop {
         let given_digits = generate_digits();
         println!("I have chosen my {} digits. Please guess what they are" ,

--- a/src/concurrent_computing.rs
+++ b/src/concurrent_computing.rs
@@ -1,16 +1,18 @@
 // http://rosettacode.org/wiki/Concurrent_computing
 extern crate rand;
-use std::thread::sleep_ms;
+
+use std::thread;
+use std::time::Duration;
+
 use rand::random;
-use std::thread::spawn;
 
 fn main() {
     let strings = vec!["Enjoy", "Rosetta", "Code"];
 
     for s in strings.into_iter(){
-        spawn(move || -> () {
+        thread::spawn(move || {
             // We use a random u8 (so an integer from 0 to 255)
-            sleep_ms(random::<u8>() as u32);
+            thread::sleep(Duration::from_millis(random::<u8>() as u64));
             println!("{}", s);
         });
     }

--- a/src/factorial.rs
+++ b/src/factorial.rs
@@ -17,7 +17,7 @@ fn factorial_iterative(n: usize) -> usize {
 // Calculate the factorial using a for loop
 fn factorial_loop(n: usize) -> usize {
     let mut fac = 1;
-    for x in (1..n+1) {
+    for x in 1..n + 1 {
         fac *= x;
     }
     fac

--- a/src/guess_number.rs
+++ b/src/guess_number.rs
@@ -7,7 +7,7 @@ fn main() {
     let mystery_number = thread_rng().gen_range(0u8, 10) + 1;
     println!("Guess my number between 1 and 10");
 
-    let mut input = stdin();
+    let input = stdin();
     loop {
         let mut line = String::new();
         let _ = input.read_line(&mut line).unwrap();

--- a/src/handle_a_signal.rs
+++ b/src/handle_a_signal.rs
@@ -1,22 +1,20 @@
 // http://rosettacode.org/wiki/Handle_a_signal
-//
-// Note that this solution only works on Unix.
-#![cfg_attr(unix, feature(std_misc))]
 
 extern crate libc;
 extern crate time;
 
+use std::mem;
+use std::sync::atomic::{AtomicBool, ATOMIC_BOOL_INIT, Ordering};
+use std::time::Duration;
+
+use libc::consts::os::posix88::SIGINT;
+use libc::funcs::posix01::signal;
+
 #[cfg(all(unix, not(test)))]
-fn main()
-{
-    use libc::consts::os::posix88::SIGINT;
-    use libc::funcs::posix01::signal;
-    use std::mem;
-    use std::sync::atomic::{AtomicBool, ATOMIC_BOOL_INIT, Ordering};
-    use time::Duration;
+fn main() {
 
     // The time between ticks of our counter.
-    let duration = 500u32; //Duration::seconds(1) / 2;
+    let duration = Duration::from_secs(1) / 2;
     // "SIGINT received" global variable.
     static mut GOT_SIGINT: AtomicBool = ATOMIC_BOOL_INIT;
     unsafe {
@@ -37,7 +35,7 @@ fn main()
     let mut i = 0u32;
     // Every `duration`...
     loop {
-        std::thread::sleep_ms(duration);
+        std::thread::sleep(duration);
         // Break if SIGINT was handled
         if unsafe { GOT_SIGINT.load(Ordering::Acquire) } { break }
         // Otherwise, increment and display the integer and continue the loop.
@@ -47,13 +45,12 @@ fn main()
     // Get the end time.
     let end = time::precise_time_ns();
     // Compute the difference
-    let diff = Duration::nanoseconds((end - start) as i64);
+    let diff = Duration::from_millis((end - start) / 1000000);
     // Print the difference and exit
-    println!("Program has run for {} seconds", diff);
+    println!("Program has run for {} seconds", diff.as_secs());
 }
 
 #[cfg(not(unix))]
-fn main()
-{
+fn main() {
     println!("Not supported on this platform");
 }

--- a/src/hough_transform.rs
+++ b/src/hough_transform.rs
@@ -113,7 +113,7 @@ fn hough(image: &ImageGray8, out_width: usize, out_height: usize) -> ImageGray8 
 
             // Project into rho,theta space
 
-            for jtx in (0..out_width) {
+            for jtx in 0..out_width {
                 let th = dth * (jtx as f64);
                 let r = (x as f64)*(th.cos()) + (y as f64)*(th.sin());
 

--- a/src/iban.rs
+++ b/src/iban.rs
@@ -29,7 +29,7 @@ fn is_valid(iban: &str) -> bool {
     };
 
     // Rearrange (first four characters go to the back)
-    for _ in (0..4) {
+    for _ in 0..4 {
         let front = iban_chars.remove(0);
         iban_chars.push(front);
     }

--- a/src/k-d-tree.rs
+++ b/src/k-d-tree.rs
@@ -239,7 +239,7 @@ fn partition_by<T>(arr: &mut [T], pivot_index: usize, cmp: &Fn(&T, &T) -> Orderi
     let array_len = arr.len();
     arr.swap(pivot_index, array_len-1);
     let mut store_index = 0;
-    for i in (0..array_len-1) {
+    for i in 0..array_len - 1 {
         if (*cmp)(&arr[i], &arr[array_len-1]) == Less {
             arr.swap(i, store_index);
             store_index += 1;

--- a/src/levenshtein_distance_alignment.rs
+++ b/src/levenshtein_distance_alignment.rs
@@ -24,10 +24,10 @@ fn levenshtein_distance(s1: &str, s2: &str) -> (usize, String, String) {
     let mut mat: Vec<Vec<usize>> = repeat(
 		repeat(0).take(l2).collect()
 		).take(l1).collect();
-    for row in (0..l1) { mat[row][0] = row; }
-    for col in (0..l2) { mat[0][col] = col; }
-    for row in (1..l1) {
-        for col in (1..l2) {
+    for row in 0..l1 { mat[row][0] = row; }
+    for col in 0..l2 { mat[0][col] = col; }
+    for row in 1..l1 {
+        for col in 1..l2 {
             mat[row][col] =
                 if s1.chars().nth(row - 1).unwrap() == s2.chars().nth(col - 1).unwrap() {
                     mat[row - 1][col - 1]

--- a/src/lzw.rs
+++ b/src/lzw.rs
@@ -7,7 +7,7 @@ fn compress(original_str: &str) -> Vec<i32> {
    let mut dict_size = 256;
    let mut dictionary = HashMap::new();
 
-   for i in (0i32..dict_size) {
+   for i in 0i32..dict_size {
       dictionary.insert(vec!(i as u8), i);
    }
 
@@ -40,7 +40,7 @@ fn decompress(compressed: &[i32]) -> String {
    let mut dict_size = 256;
    let mut dictionary = HashMap::new();
 
-   for i in (0i32..dict_size) {
+   for i in 0i32..dict_size {
       dictionary.insert(i, vec![i as u8]);
    }
 

--- a/src/md5-implementation.rs
+++ b/src/md5-implementation.rs
@@ -115,7 +115,7 @@ fn md5(initial_msg: &[u8]) -> MD5
         let (mut a, mut b, mut c, mut d) = (h[0], h[1], h[2], h[3]);
 
         // Main loop:
-        for ind in (0..64) {
+        for ind in 0..64 {
             let (f,g) = match ind {
                 i @ 0...15  => ( (b & c) | ((!b) & d), //f
                                 i ),                   //g

--- a/src/metered_concurrency.rs
+++ b/src/metered_concurrency.rs
@@ -66,7 +66,7 @@ fn metered(duration: u32) {
     let sem = Arc::new(CountingSemaphore::new(MAX_COUNT, backoff));
     // Create a channel for notifying the main task that the workers are done
     let (tx, rx) = channel();
-    for i in (0..NUM_WORKERS) {
+    for i in 0..NUM_WORKERS {
         let sem = sem.clone();
         let tx = tx.clone();
         spawn(move || -> () {
@@ -90,7 +90,7 @@ fn metered(duration: u32) {
     }
     drop(tx);
     // Wait for all the subtasks to finish
-    for _ in (0..NUM_WORKERS) {
+    for _ in 0..NUM_WORKERS {
         rx.recv().unwrap();
     }
 }

--- a/src/pascals_triangle.rs
+++ b/src/pascals_triangle.rs
@@ -3,11 +3,11 @@
 fn pascaltriangle(rows: usize) -> Vec<Vec<usize>> {
     let mut all_rows = Vec::with_capacity(rows);
 
-    for row in (0..rows) {
+    for row in 0..rows {
         let mut row_vals = Vec::with_capacity(row + 1);
         let mut value = 1;
 
-        for col in (0..row + 1) {
+        for col in 0..row + 1 {
             row_vals.push(value);
             value = value * (row - col)/(col + 1)
         }

--- a/src/penneys_game.rs
+++ b/src/penneys_game.rs
@@ -4,6 +4,8 @@
 extern crate rand;
 
 use std::io::{stdout, stdin, Read, Write};
+use std::thread;
+use std::time::Duration;
 use rand::{Rng, thread_rng};
 
 fn toss_coin(print:bool) -> char {
@@ -76,11 +78,11 @@ fn main() {
         let mut coins = String::new();
         for _ in 0..2 { //toss first 2 coins
             coins.push(toss_coin(true));
-            std::thread::sleep_ms(500);
+            thread::sleep(Duration::from_millis(500));
         }
         loop {
             coins.push(toss_coin(true));
-            std::thread::sleep_ms(500);
+            thread::sleep(Duration::from_millis(500));
             if coins.contains(&useq) {
                 println!("\nYou win!");
                 break;

--- a/src/proper_divisors.rs
+++ b/src/proper_divisors.rs
@@ -64,7 +64,7 @@ fn main() {
     //Find a number in the range 1 to 20,000
     //with the most proper divisors.
     let mut max_divs:(usize, Vec<usize>)=(0,Vec::new());
-    for n in (1..20001) {
+    for n in 1..20001 {
         let div_q = find_divisors(&mut primes,n).len();
         if div_q > max_divs.0 {
             max_divs.0 = div_q;

--- a/src/pythagorean_triples.rs
+++ b/src/pythagorean_triples.rs
@@ -44,7 +44,7 @@ fn count_pythagorean_triples(below: u64) -> (u64, u64) {
 
 #[cfg(not(test))]
 fn main() {
-    for n in (1..9) {
+    for n in 1..9 {
         let (tot, prim) = count_pythagorean_triples(10u64.pow(n));
         println!("Up to 10^{}: {:>10} triples {:>10} primitives",
                  n, tot, prim);

--- a/src/self-describing_numbers.rs
+++ b/src/self-describing_numbers.rs
@@ -31,7 +31,7 @@ fn is_self_describing(mut n: u64) -> bool {
 #[cfg(not(test))]
 fn main() {
     // Print out all self-describing numbers below 10^8
-    for i in (0u64..100_000_000) {
+    for i in 0u64..100_000_000 {
         if is_self_describing(i) {
             println!("{} is self-describing", i);
         }

--- a/src/sierpinski_triangle.rs
+++ b/src/sierpinski_triangle.rs
@@ -8,12 +8,12 @@ fn main() {
     let mut state: Vec<bool> = repeat(true).take(height + 1).collect();
 
     // Compute the triangle line-by-line by viewing it as Pascal's triangle (mod 2)
-    for i in (0..height) {
-        for _ in (0..height - i - 1) {
+    for i in 0..height {
+        for _ in 0..height - i - 1 {
             print!(" ");
         }
 
-        for j in (0..i + 1) {
+        for j in 0..i + 1 {
             print!(" {}", if state[j] { "*" } else { " " });
         }
 

--- a/src/tic_tac_toe.rs
+++ b/src/tic_tac_toe.rs
@@ -44,7 +44,7 @@ fn main() {
 
 fn check_win(board: [[char; 3]; 3]) -> GameState {
 	// check for win
-	for i in (0..3) {
+	for i in 0..3 {
 		if board[i][0] == board[i][1] && board[i][0] == board[i][2] {
 			return which_win(board[i][0])
 		} else if board[0][i] == board[1][i] && board[0][i] == board[2][i] {
@@ -103,8 +103,8 @@ fn computer_turn(board: &mut [[char; 3]; 3]) {
 	let mut rng = thread_rng();
 
 	let mut possible_choices: Vec<char> = vec![];
-	for row_i in (0..3) {
-		for col_i in (0..3) {
+	for row_i in 0..3 {
+		for col_i in 0..3 {
 			if board[row_i][col_i] != 'X' && board[row_i][col_i] != 'O' {
 				possible_choices.push(board[row_i][col_i]);
 			}

--- a/src/wireworld.rs
+++ b/src/wireworld.rs
@@ -1,6 +1,8 @@
 // http://rosettacode.org/wiki/Wireworld
 
 use std::mem;
+use std::thread;
+use std::time::Duration;
 
 // Use VT100 cursor control sequences to animate in-place
 #[cfg(not(test))] const ANIMATE: bool = true;
@@ -53,7 +55,6 @@ fn next_world(input: &[Cell], output: &mut [Cell], w: usize, h: usize) {
 
 #[cfg(not(test))]
 fn main() {
-    use std::thread::sleep_ms;
     let (w, h) = (14usize, 7usize);
     let mut world: Vec<Cell> = "
 +-----------+
@@ -77,7 +78,7 @@ fn main() {
         if ANIMATE {
             print!("\x1b[{}A", 8);
             print!("\x1b[{}D", 14);
-            sleep_ms(100);
+            thread::sleep(Duration::from_millis(100));
         }
     }
 }


### PR DESCRIPTION
This PR fixes unused_parens, unused_mut, and deprecated warnings.

The inclusive range syntax is __not__ included because that syntax has not yet been merged.

Almost done with #417!