### PR TITLE
join on threads in concurrent_computing

### DIFF
--- a/src/concurrent_computing.rs
+++ b/src/concurrent_computing.rs
@@ -9,11 +9,17 @@ use rand::random;
 fn main() {
     let strings = vec!["Enjoy", "Rosetta", "Code"];
 
+    let mut children = vec![];
+
     for s in strings.into_iter(){
-        thread::spawn(move || {
+        children.push(thread::spawn(move || {
             // We use a random u8 (so an integer from 0 to 255)
             thread::sleep(Duration::from_millis(random::<u8>() as u64));
             println!("{}", s);
-        });
+        }));
+    }
+
+    for child in children {
+        child.join().unwrap();
     }
 }


### PR DESCRIPTION
In the current implementation, the main thread exits before the threads finish,
meaning that there is no output.