### PR TITLE
add --unimplemented flag to coverage

### DIFF
--- a/coverage/Cargo.lock
+++ b/coverage/Cargo.lock
@@ -279,6 +279,7 @@ dependencies = [
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "schedule_recv 0.0.1 (git+https://github.com/PeterReid/schedule_recv)",
  "time 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -343,6 +344,14 @@ dependencies = [
  "kernel32-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "toml"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/coverage/src/main.rs
+++ b/coverage/src/main.rs
@@ -36,13 +36,14 @@ If no tasks are specified, determines the status for all tasks.
 Optionally prints out a diff as well.
 
 Usage:
-    coverage [options] [--localonly | --remoteonly] [<tasks>...]
+    coverage [options] [--localonly | --remoteonly | --unimplemented] [<tasks>...]
 
 Options:
-    -h --help       Show this screen.
-    --nodiff        Don't print diffs.
-    --localonly     Only print tasks that are implemented locally, but not on the wiki.
-    --remoteonly    Only print tasks that are implemented on the wiki, but not locally.
+    -h --help           Show this screen.
+    --nodiff            Don't print diffs.
+    --localonly         Only print tasks that are implemented locally, but not on the wiki.
+    --remoteonly        Only print tasks that are implemented on the wiki, but not locally.
+    --unimplemented     Only print tasks that neither implemented locally nor remotely.
 ";
 
 #[derive(Debug, RustcDecodable)]
@@ -51,6 +52,7 @@ struct Args {
     flag_nodiff: bool,
     flag_localonly: bool,
     flag_remoteonly: bool,
+    flag_unimplemented: bool,
 }
 
 // Normalizes a title according to MediaWiki's rules.
@@ -128,6 +130,10 @@ fn main() {
         }
 
         if args.flag_remoteonly && !(local_code.is_none() && online_code.is_some()) {
+            continue
+        }
+
+        if args.flag_unimplemented && (local_code.is_some() || online_code.is_some()) {
             continue
         }
 


### PR DESCRIPTION
This allows users to print out only tasks that are neither on the wiki nor in
the repository.