### PR TITLE
implement "Use another language to call a function"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,7 @@ dependencies = [
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "use-another-language-to-call-a-function 1.0.0",
 ]
 
 [[package]]
@@ -395,6 +396,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "use-another-language-to-call-a-function"
+version = "1.0.0"
+dependencies = [
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,10 @@ unicode-segmentation = "0.1"
 # dependency does not compile on Windows, currently only used for 2048
 rustbox = { version = "*", optional = true }
 
+# subcrates
+[dependencies.use-another-language-to-call-a-function]
+path = "src/use_another_language_to_call_a_function"
+
 [build-dependencies]
 regex = "0.1"
 toml = "0.1"
@@ -1328,6 +1332,11 @@ test = false
 name = "unix_ls"
 path = "src/unix/ls.rs"
 test = false
+
+[[bin]]
+# http://rosettacode.org/wiki/Use_another_language_to_call_a_function
+name = "use_another_language_to_call_a_function"
+path = "src/use_another_language_to_call_a_function.rs"
 
 [[bin]]
 # http://rosettacode.org/wiki/Vigen%C3%A8re_cipher

--- a/src/use_another_language_to_call_a_function.rs
+++ b/src/use_another_language_to_call_a_function.rs
@@ -1,0 +1,32 @@
+// http://rosettacode.org/wiki/Use_another_language_to_call_a_function
+extern crate use_another_language_to_call_a_function;
+
+use use_another_language_to_call_a_function::*;
+
+#[test]
+fn buffer_too_small() {
+    unsafe {
+        const BUF_SIZE: usize = 3;
+        let mut buffer = [0; BUF_SIZE];
+        assert_eq!(0, Query(buffer.as_mut_ptr(), &mut BUF_SIZE));
+    }
+}
+
+#[test]
+fn buffer_contains_data() {
+    use std::ffi::{CStr, CString};
+
+    unsafe {
+        const BUF_SIZE: usize = 1024;
+        let mut buffer = [0; BUF_SIZE];
+        assert_eq!(1, Query(buffer.as_mut_ptr(), &mut BUF_SIZE));
+        assert_eq!(CString::new("Here am I").unwrap(),
+                   CStr::from_ptr(buffer.as_ptr()).to_owned());
+    }
+}
+
+fn main() {
+    println!("This task is not a binary.");
+    println!("Please see the comment at the top of \
+             src/use_another_language_to_call_a_function/src/lib.rs.");
+}

--- a/src/use_another_language_to_call_a_function/.gitignore
+++ b/src/use_another_language_to_call_a_function/.gitignore
@@ -1,0 +1,1 @@
+Cargo.lock

--- a/src/use_another_language_to_call_a_function/Cargo.toml
+++ b/src/use_another_language_to_call_a_function/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "use-another-language-to-call-a-function"
+version = "1.0.0"
+authors = ["Andy Russell, https://github.com/euclio"]
+
+[dependencies]
+libc = "0.2"
+
+[lib]
+crate_type = ["dylib"]

--- a/src/use_another_language_to_call_a_function/src/lib.rs
+++ b/src/use_another_language_to_call_a_function/src/lib.rs
@@ -1,0 +1,33 @@
+// http://rosettacode.org/wiki/Use_another_language_to_call_a_function
+//
+// In order to run this task, you will need to compile the C program locating in the task linked
+// above. The C program will need to be linked with the library produced by this file.
+//
+// 1. Compile this library:
+//      $ rustc -L /path/to/folder/containing/libc src/use_another_language_to_call_a_function.rs \
+//          -o libquery
+// 2. Copy the C program into query.c.
+// 3. Compile and link the C program with the produced library:
+//      $ LD_LIBRARY_PATH=/path/to/libquery gcc query.c -o query -Wall -Werror libquery
+// 4. Run the resulting binary.
+//      $ LD_LIBRARY_PATH=/path/to/libquery ./query
+//      Here am I
+#![crate_type = "dylib"]
+extern crate libc;
+
+use std::ffi::CString;
+
+use libc::{c_char, c_int, size_t};
+
+#[no_mangle]
+#[allow(non_snake_case)]
+pub unsafe extern fn Query(data: *mut c_char, length: *mut size_t) -> c_int {
+    let string = "Here am I";
+    if *length + 1 < string.len() {
+        0
+    } else {
+        libc::strcpy(data, CString::new(string).unwrap().as_ptr());
+        *length = string.len();
+        1
+    }
+}


### PR DESCRIPTION
One problem with this PR is that it must be implemented as a library. Since cargo requires that each project only have one library, I think that it's best implemented as a subcrate.

We'll have to think of a way for `coverage` to deal with these special cases.