### PR TITLE
Iteration: use ".." syntax instead of range_inclusive [deprecated]

### DIFF
--- a/src/loops/downward_for.rs
+++ b/src/loops/downward_for.rs
@@ -1,9 +1,7 @@
 // http://rosettacode.org/wiki/Loops/Downward_for
-#![feature(range_inclusive)]
-use std::iter::range_inclusive;
 
 fn main() {
-    for i in range_inclusive(1, 10).rev() {
+    for i in (1 .. 10 + 1).rev() {
         println!("{}", i);
     }
 }

--- a/src/sum_of_a_series.rs
+++ b/src/sum_of_a_series.rs
@@ -1,9 +1,6 @@
 // http://rosettacode.org/wiki/Sum_of_a_series
-#![feature(range_inclusive)]
-
-use std::iter::range_inclusive;
 
 fn main() {
-    let sum: f64 = range_inclusive(1u64, 1000).fold(0.,|sum, num| sum + 1./(num*num) as f64);
+    let sum: f64 = (1u64 .. 1000 + 1).fold(0.,|sum, num| sum + 1./(num*num) as f64);
     println!("{}", sum);
 }


### PR DESCRIPTION
It is not possible to adapt this syntax for count_in_octal example due
to overflow. Introducing "..." syntax in the future helps to solve this
problem.