### PR TITLE
Check graphemes in line length check, not bytes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ rustbox = { version = "*", optional = true }
 [build-dependencies]
 regex = "0.1"
 toml = "0.1"
+unicode-segmentation = "0.1.2"
 
 [dependencies.schedule_recv]
 git = "https://github.com/PeterReid/schedule_recv"

--- a/build.rs
+++ b/build.rs
@@ -30,7 +30,12 @@ fn check_toml() {
 
     for (bin, correct_bin) in binaries.iter().zip(sorted_binaries) {
         let bin_name = bin.as_table().unwrap().get("name").unwrap().as_str().unwrap();
-        let correct_bin_name = correct_bin.as_table().unwrap().get("name").unwrap().as_str().unwrap();
+        let correct_bin_name = correct_bin.as_table()
+                                          .unwrap()
+                                          .get("name")
+                                          .unwrap()
+                                          .as_str()
+                                          .unwrap();
         if bin_name != correct_bin_name {
             panic!("{} is not in the correct order in Cargo.toml!", bin_name);
         }
@@ -40,8 +45,9 @@ fn check_toml() {
 fn main() {
     check_toml();
 
-    let files = fs::read_dir("src").unwrap()
-                                   .map(|e| e.unwrap());
+    let files = fs::read_dir("src")
+                    .unwrap()
+                    .map(|e| e.unwrap());
 
     for f in files {
         let path = f.path();
@@ -60,8 +66,10 @@ fn check(path: &Path) {
             // Ensure the first line has a URL of the proper form
             let task_comment = Regex::new(r"// http://rosettacode\.org/wiki/.+").unwrap();
             if !task_comment.is_match(line) {
-                line_error(i + 1, path, "file does not start with \
-                           \"// http://rosettacode.org/wiki/<TASK NAME>\"");
+                line_error(i + 1,
+                           path,
+                           "file does not start with \"// http://rosettacode.org/wiki/<TASK \
+                            NAME>\"");
             }
         }
 
@@ -86,5 +94,7 @@ fn check(path: &Path) {
 
 fn line_error(line: usize, path: &Path, msg: &str) {
     panic!("Formatting error, {} (line {} of file \"{}\")",
-           msg, line, path.to_str().unwrap())
+           msg,
+           line,
+           path.to_str().unwrap())
 }

--- a/build.rs
+++ b/build.rs
@@ -7,12 +7,14 @@
 // the cause of the problem.
 extern crate regex;
 extern crate toml;
+extern crate unicode_segmentation;
 
 use std::fs::{self, File, metadata};
 use std::io::Read;
 use std::path::Path;
 
 use regex::Regex;
+use unicode_segmentation::UnicodeSegmentation;
 
 fn check_toml() {
     let mut cargo_toml_file = File::open("Cargo.toml").unwrap();
@@ -79,7 +81,7 @@ fn check(path: &Path) {
         }
 
         // Check length
-        if line.len() > 100 {
+        if UnicodeSegmentation::graphemes(line, true).count() > 100 {
             line_error(i + 1, path, "line is longer than 100 characters");
         }
 


### PR DESCRIPTION
Currently the style check checks the number of bytes in a line, not the unicode grapheme clusters. This causes the script to fail when there are a large number of unicode characters in a single line, even if there are fewer than 100 characters visually. I also took this opportunity to run `rustfmt` on the build script.