### PR TITLE
Add remote-only tasks to repo, part deux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,6 +8,7 @@ dependencies = [
  "gtk 0.0.7 (git+https://github.com/gtk-rs/gtk.git)",
  "hyper 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ncurses 5.80.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "permutohedron 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -373,6 +374,14 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ncurses"
+version = "5.80.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,6 +5,7 @@ dependencies = [
  "docopt 0.6.75 (registry+https://github.com/rust-lang/crates.io-index)",
  "eventual 0.1.4 (git+https://github.com/carllerche/eventual)",
  "factorial-plugin 1.0.0",
+ "gtk 0.0.7 (git+https://github.com/gtk-rs/gtk.git)",
  "hyper 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -40,6 +41,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "atk-sys"
+version = "0.3.0"
+source = "git+https://github.com/gtk-rs/sys#2ae6e903c6b6f75ad6d277bf9e96acbcd74f9ba9"
+dependencies = [
+ "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib-sys 0.3.0 (git+https://github.com/gtk-rs/sys)",
+ "gobject-sys 0.3.0 (git+https://github.com/gtk-rs/sys)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bitflags"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,6 +61,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "bitflags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "c_vec"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cairo-rs"
+version = "0.0.8"
+source = "git+https://github.com/gtk-rs/cairo#7caa638f32f425dff8543291787bda8ba05a3144"
+dependencies = [
+ "c_vec 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cairo-sys-rs 0.3.0 (git+https://github.com/gtk-rs/cairo)",
+ "glib 0.0.8 (git+https://github.com/gtk-rs/glib)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cairo-sys-rs"
+version = "0.3.0"
+source = "git+https://github.com/gtk-rs/cairo#7caa638f32f425dff8543291787bda8ba05a3144"
+dependencies = [
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "cookie"
@@ -100,6 +143,136 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "advapi32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gdk"
+version = "0.3.0"
+source = "git+https://github.com/gtk-rs/gdk#6ea1497e39e5b44d3fcfde1f737b76e66325a6dd"
+dependencies = [
+ "cairo-rs 0.0.8 (git+https://github.com/gtk-rs/cairo)",
+ "gdk-pixbuf 0.0.1 (git+https://github.com/gtk-rs/gdk-pixbuf)",
+ "gdk-sys 0.3.0 (git+https://github.com/gtk-rs/sys)",
+ "glib 0.0.8 (git+https://github.com/gtk-rs/glib)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pango 0.0.7 (git+https://github.com/gtk-rs/pango)",
+]
+
+[[package]]
+name = "gdk-pixbuf"
+version = "0.0.1"
+source = "git+https://github.com/gtk-rs/gdk-pixbuf#e1b2838e4af15174fbe530215ad932c89bb2d958"
+dependencies = [
+ "gdk-pixbuf-sys 0.3.0 (git+https://github.com/gtk-rs/sys)",
+ "glib 0.0.8 (git+https://github.com/gtk-rs/glib)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gdk-pixbuf-sys"
+version = "0.3.0"
+source = "git+https://github.com/gtk-rs/sys#2ae6e903c6b6f75ad6d277bf9e96acbcd74f9ba9"
+dependencies = [
+ "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gio-sys 0.3.0 (git+https://github.com/gtk-rs/sys)",
+ "glib-sys 0.3.0 (git+https://github.com/gtk-rs/sys)",
+ "gobject-sys 0.3.0 (git+https://github.com/gtk-rs/sys)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gdk-sys"
+version = "0.3.0"
+source = "git+https://github.com/gtk-rs/sys#2ae6e903c6b6f75ad6d277bf9e96acbcd74f9ba9"
+dependencies = [
+ "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cairo-sys-rs 0.3.0 (git+https://github.com/gtk-rs/cairo)",
+ "gdk-pixbuf-sys 0.3.0 (git+https://github.com/gtk-rs/sys)",
+ "gio-sys 0.3.0 (git+https://github.com/gtk-rs/sys)",
+ "glib-sys 0.3.0 (git+https://github.com/gtk-rs/sys)",
+ "gobject-sys 0.3.0 (git+https://github.com/gtk-rs/sys)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pango-sys 0.3.0 (git+https://github.com/gtk-rs/sys)",
+ "pkg-config 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gio-sys"
+version = "0.3.0"
+source = "git+https://github.com/gtk-rs/sys#2ae6e903c6b6f75ad6d277bf9e96acbcd74f9ba9"
+dependencies = [
+ "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib-sys 0.3.0 (git+https://github.com/gtk-rs/sys)",
+ "gobject-sys 0.3.0 (git+https://github.com/gtk-rs/sys)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "glib"
+version = "0.0.8"
+source = "git+https://github.com/gtk-rs/glib#57d672e0be777226f145c49bec55d44b2bec325d"
+dependencies = [
+ "gio-sys 0.3.0 (git+https://github.com/gtk-rs/sys)",
+ "glib-sys 0.3.0 (git+https://github.com/gtk-rs/sys)",
+ "gobject-sys 0.3.0 (git+https://github.com/gtk-rs/sys)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "glib-sys"
+version = "0.3.0"
+source = "git+https://github.com/gtk-rs/sys#2ae6e903c6b6f75ad6d277bf9e96acbcd74f9ba9"
+dependencies = [
+ "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gobject-sys"
+version = "0.3.0"
+source = "git+https://github.com/gtk-rs/sys#2ae6e903c6b6f75ad6d277bf9e96acbcd74f9ba9"
+dependencies = [
+ "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib-sys 0.3.0 (git+https://github.com/gtk-rs/sys)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gtk"
+version = "0.0.7"
+source = "git+https://github.com/gtk-rs/gtk.git#2156bea80a69580a96daf64529f4961a68c36f53"
+dependencies = [
+ "cairo-rs 0.0.8 (git+https://github.com/gtk-rs/cairo)",
+ "cairo-sys-rs 0.3.0 (git+https://github.com/gtk-rs/cairo)",
+ "gdk 0.3.0 (git+https://github.com/gtk-rs/gdk)",
+ "gdk-sys 0.3.0 (git+https://github.com/gtk-rs/sys)",
+ "glib 0.0.8 (git+https://github.com/gtk-rs/glib)",
+ "glib-sys 0.3.0 (git+https://github.com/gtk-rs/sys)",
+ "gtk-sys 0.3.0 (git+https://github.com/gtk-rs/sys)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pango 0.0.7 (git+https://github.com/gtk-rs/pango)",
+]
+
+[[package]]
+name = "gtk-sys"
+version = "0.3.0"
+source = "git+https://github.com/gtk-rs/sys#2ae6e903c6b6f75ad6d277bf9e96acbcd74f9ba9"
+dependencies = [
+ "atk-sys 0.3.0 (git+https://github.com/gtk-rs/sys)",
+ "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cairo-sys-rs 0.3.0 (git+https://github.com/gtk-rs/cairo)",
+ "gdk-pixbuf-sys 0.3.0 (git+https://github.com/gtk-rs/sys)",
+ "gdk-sys 0.3.0 (git+https://github.com/gtk-rs/sys)",
+ "gio-sys 0.3.0 (git+https://github.com/gtk-rs/sys)",
+ "glib-sys 0.3.0 (git+https://github.com/gtk-rs/sys)",
+ "gobject-sys 0.3.0 (git+https://github.com/gtk-rs/sys)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pango-sys 0.3.0 (git+https://github.com/gtk-rs/sys)",
+ "pkg-config 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -238,6 +411,28 @@ dependencies = [
  "gcc 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "libressl-pnacl-sys 2.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pango"
+version = "0.0.7"
+source = "git+https://github.com/gtk-rs/pango#d5e8c8718d0d34cf069c4fbad0b705d8b0591846"
+dependencies = [
+ "glib 0.0.8 (git+https://github.com/gtk-rs/glib)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pango-sys 0.3.0 (git+https://github.com/gtk-rs/sys)",
+]
+
+[[package]]
+name = "pango-sys"
+version = "0.3.0"
+source = "git+https://github.com/gtk-rs/sys#2ae6e903c6b6f75ad6d277bf9e96acbcd74f9ba9"
+dependencies = [
+ "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib-sys 0.3.0 (git+https://github.com/gtk-rs/sys)",
+ "gobject-sys 0.3.0 (git+https://github.com/gtk-rs/sys)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,7 @@ dependencies = [
  "permutohedron 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-crypto 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustbox 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "schedule_recv 0.0.1 (git+https://github.com/PeterReid/schedule_recv)",
@@ -487,6 +488,18 @@ dependencies = [
 name = "regex-syntax"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rust-crypto"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gcc 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rustbox"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -407,6 +407,11 @@ name = "closures_value_capture"
 path = "src/closures/value_capture.rs"
 
 [[bin]]
+# http://rosettacode.org/wiki/Collections
+name = "collections"
+path = "src/collections.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Combinations
 name = "combinations"
 path = "src/combinations.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -392,6 +392,11 @@ name = "chinese_remainder"
 path = "src/chinese_remainder.rs"
 
 [[bin]]
+# http://rosettacode.org/wiki/Circles_of_given_radius_through_two_points
+name = "circles_of_given_radius_through_two_points"
+path = "src/circles_of_given_radius_through_two_points.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Closest-pair_problem
 name = "closest-pair"
 path = "src/closest-pair.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1404,6 +1404,11 @@ name = "s_expressions"
 path = "src/s_expressions.rs"
 
 [[bin]]
+# http://rosettacode.org/wiki/Search_a_list
+name = "search_a_list"
+path = "src/search_a_list.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Self-describing_numbers
 name = "self-describing_numbers"
 path = "src/self-describing_numbers.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ authors = [
 
 [features]
 unixOnly = ["rustbox"]
+with-gtk = ["gtk"]
 
 [dependencies]
 regex = "0.1"
@@ -78,6 +79,9 @@ url = "0.5"
 
 # dependency does not compile on Windows, currently only used for 2048
 rustbox = { version = "*", optional = true }
+
+# requires GTK library
+gtk = { git = "https://github.com/gtk-rs/gtk.git", optional = true }
 
 # subcrates
 [dependencies.use-another-language-to-call-a-function]
@@ -758,6 +762,11 @@ path = "src/hash_from_two_arrays.rs"
 # http://rosettacode.org/wiki/Hash_join
 name = "hash_join"
 path = "src/hash_join.rs"
+
+[[bin]]
+# http://rosettacode.org/wiki/Hello_world/Graphical
+name = "hello_world_graphical"
+path = "src/hello_world/graphical.rs"
 
 [[bin]]
 # http://rosettacode.org/wiki/Hello_world/Newline_omission

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -511,6 +511,11 @@ name = "dot_product"
 path = "src/dot_product.rs"
 
 [[bin]]
+# http://www.rosettacode.org/wiki/Doubly-linked_list/Element_definition
+name = "doubly_linked_list_element_definition"
+path = "src/doubly_linked_list/element_definition.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Echo_server
 name = "echo_server"
 path = "src/echo_server.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1245,6 +1245,11 @@ name = "prime_decomposition"
 path = "src/prime_decomposition.rs"
 
 [[bin]]
+# https://rosettacode.org/wiki/Program_name
+name = "program_name"
+path = "src/program_name.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Proper_divisors
 name = "proper_divisors"
 path = "src/proper_divisors.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -433,6 +433,11 @@ name = "compile_time_calculation"
 path = "src/compile_time_calculation.rs"
 
 [[bin]]
+# http://rosettacode.org/wiki/Compound_data_type
+name = "compound_data_type"
+path = "src/compound_data_type.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Concurrent_computing
 name = "concurrent_computing"
 path = "src/concurrent_computing.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1260,6 +1260,11 @@ name = "pythagorean_triples"
 path = "src/pythagorean_triples.rs"
 
 [[bin]]
+# http://rosettacode.org/wiki/Queue/Definition
+name = "queue_definition"
+path = "src/queue/definition.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Range_expansion
 name = "range_expansion"
 path = "src/range_expansion.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1148,6 +1148,11 @@ name = "number_classifications"
 path = "src/number_classifications.rs"
 
 [[bin]]
+# http://rosettacode.org/wiki/Numerical_integration
+name = "numerical_integration"
+path = "src/numerical_integration.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Ordered_words
 name = "ordered_words"
 path = "src/ordered_words.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -849,6 +849,11 @@ name = "iban"
 path = "src/iban.rs"
 
 [[bin]]
+# http://rosettacode.org/wiki/Include_a_file
+name = "include_a_file"
+path = "src/include_a_file.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Infinity
 name = "infinity"
 path = "src/infinity.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1329,6 +1329,11 @@ name = "replace_word"
 path = "src/replace_word.rs"
 
 [[bin]]
+# http://rosettacode.org/wiki/Return_multiple_values
+name = "return_multiple_values"
+path = "src/return_multiple_values.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Reverse_a_string
 name = "reverse_a_string"
 path = "src/reverse_a_string.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -769,6 +769,11 @@ name = "hello_world_graphical"
 path = "src/hello_world/graphical.rs"
 
 [[bin]]
+# http://www.rosettacode.org/wiki/Hello_world/Line_printer
+name = "hello_world_line_printer"
+path = "src/hello_world/line_printer.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Hello_world/Newline_omission
 name = "hello_world_newline_omission"
 path = "src/hello_world/newline_omission.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -240,6 +240,11 @@ name = "arithmetic_rational"
 path = "src/arithmetic/rational.rs"
 
 [[bin]]
+# http://www.rosettacode.org/wiki/Array_length
+name = "array_length"
+path = "src/array_length.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Arrays
 name = "arrays"
 path = "src/arrays.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -697,6 +697,11 @@ path = "src/greater_element_list.rs"
 test = false
 
 [[bin]]
+# http://rosettacode.org/wiki/Greatest_subsequential_sum
+name = "greatest_subsequential_sum"
+path = "src/greatest_subsequential_sum.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Guess_the_number
 name = "guess_number"
 path = "src/guess_number.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1537,6 +1537,11 @@ name = "stdev"
 path = "src/stdev.rs"
 
 [[bin]]
+# http://rosettacode.org/wiki/String_case
+name = "string_case"
+path = "src/string_case.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/String_concatenation
 name = "string_concatenation"
 path = "src/string_concatenation.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -516,6 +516,11 @@ name = "doubly_linked_list_element_definition"
 path = "src/doubly_linked_list/element_definition.rs"
 
 [[bin]]
+# http://www.rosettacode.org/wiki/Doubly-linked_list/Element_insertion
+name = "doubly_linked_list_element_insertion"
+path = "src/doubly_linked_list/element_insertion.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Echo_server
 name = "echo_server"
 path = "src/echo_server.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -407,6 +407,11 @@ name = "closures_value_capture"
 path = "src/closures/value_capture.rs"
 
 [[bin]]
+# http://rosettacode.org/wiki/Combinations
+name = "combinations"
+path = "src/combinations.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Comma_quibbling
 name = "comma_quibbling"
 path = "src/comma_quibbling.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1477,6 +1477,11 @@ name = "sleep"
 path = "src/sleep.rs"
 
 [[bin]]
+# http://rosettacode.org/wiki/Sockets
+name = "sockets"
+path = "src/sockets.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Sort_an_integer_array
 name = "sort_int"
 path = "src/sort_int.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1270,6 +1270,11 @@ name = "quine"
 path = "src/quine.rs"
 
 [[bin]]
+# http://rosettacode.org/wiki/Random_numbers
+name = "random_numbers"
+path = "src/random_numbers.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Range_expansion
 name = "range_expansion"
 path = "src/range_expansion.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ authors = [
 [features]
 unixOnly = ["rustbox"]
 with-gtk = ["gtk"]
+with-ncurses = ["ncurses"]
 
 [dependencies]
 regex = "0.1"
@@ -82,6 +83,9 @@ rustbox = { version = "*", optional = true }
 
 # requires GTK library
 gtk = { git = "https://github.com/gtk-rs/gtk.git", optional = true }
+
+# required ncurses library
+ncurses = { version = "5.80", optional = true }
 
 # subcrates
 [dependencies.use-another-language-to-call-a-function]
@@ -916,6 +920,11 @@ path = "src/k-d-tree.rs"
 # http://rosettacode.org/wiki/Kahan_summation
 name = "kahansum"
 path = "src/kahansum.rs"
+
+[[bin]]
+# http://rosettacode.org/wiki/Keyboard_input/Obtain_a_Y_or_N_response
+name = "keyboard_input_obtain_a_y_or_n_response"
+path = "src/keyboard_input/obtain_a_y_or_n_response.rs"
 
 [[bin]]
 # http://rosettacode.org/wiki/Knapsack_problem/0-1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1092,6 +1092,11 @@ name = "menu"
 path = "src/menu.rs"
 
 [[bin]]
+# https://rosettacode.org/wiki/Metaprogramming
+name = "metaprogramming"
+path = "src/metaprogramming.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Metered_concurrency
 name = "metered_concurrency"
 path = "src/metered_concurrency.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -872,6 +872,11 @@ path = "src/input_loop.rs"
 test = false
 
 [[bin]]
+# http://rosettacode.org/wiki/Integer_comparison
+name = "integer_comparison"
+path = "src/integer_comparison.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Integer_sequence
 name = "integer_sequence"
 path = "src/integer_sequence.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1280,6 +1280,11 @@ name = "range_expansion"
 path = "src/range_expansion.rs"
 
 [[bin]]
+# http://rosettacode.org/wiki/Range_extraction
+name = "range_extraction"
+path = "src/range_extraction.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Read_a_file_line_by_line
 name = "read_file_line"
 path = "src/read_file_line.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1457,6 +1457,11 @@ name = "sieve_eratosthenes"
 path = "src/sieve_eratosthenes.rs"
 
 [[bin]]
+# http://rosettacode.org/wiki/Singly-linked_list/Element_definition
+name = "singly_linked_list_element_definition"
+path = "src/singly_linked_list/element_definition.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Sleep
 name = "sleep"
 path = "src/sleep.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1071,6 +1071,11 @@ name = "markov_algorithm"
 path = "src/markov_algorithm.rs"
 
 [[bin]]
+# http://rosettacode.org/wiki/Maximum_triangle_path_sum
+name = "maximum_triangle_path_sum"
+path = "src/maximum_triangle_path_sum.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/MD5/Implementation
 name = "md5_implementation"
 path = "src/md5/implementation.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -713,6 +713,11 @@ name = "guess_the_number_with_feedback"
 path = "src/guess_the_number/with_feedback.rs"
 
 [[bin]]
+# http://www.rosettacode.org/wiki/Guess_the_number/With_feedback_(player)
+name = "guess_the_number_with_feedback_player"
+path = "src/guess_the_number/with_feedback_player.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Hailstone_sequence
 name = "hailstone"
 path = "src/hailstone.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1265,6 +1265,11 @@ name = "queue_definition"
 path = "src/queue/definition.rs"
 
 [[bin]]
+# http://rosettacode.org/wiki/Quine
+name = "quine"
+path = "src/quine.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Range_expansion
 name = "range_expansion"
 path = "src/range_expansion.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -339,6 +339,11 @@ name = "bulls_and_cows"
 path = "src/bulls_and_cows.rs"
 
 [[bin]]
+# http://rosettacode.org/wiki/Caesar_cipher
+name = "caesar_cipher"
+path = "src/caesar_cipher.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Call_an_object_method
 name = "call_an_object_method"
 path = "src/call_an_object_method.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -575,6 +575,11 @@ name = "eulers_sum_of_powers_conjecture"
 path = "src/eulers_sum_of_powers_conjecture.rs"
 
 [[bin]]
+# http://rosettacode.org/wiki/Even_or_odd
+name = "even_or_odd"
+path = "src/even_or_odd.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Events
 name = "events"
 path = "src/events.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -539,6 +539,11 @@ path = "src/empty_directory.rs"
 test = false
 
 [[bin]]
+# http://rosettacode.org/wiki/Enforced_mutability
+name = "enforced_immutability"
+path = "src/enforced_immutability.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Entropy
 name = "entropy"
 path = "src/entropy.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1467,6 +1467,11 @@ name = "singly_linked_list_element_insertion"
 path = "src/singly_linked_list/element_insertion.rs"
 
 [[bin]]
+# http://rosettacode.org/wiki/Singly-linked_list/Traversal
+name = "singly_linked_list_traversal"
+path = "src/singly_linked_list/traversal.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Sleep
 name = "sleep"
 path = "src/sleep.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1118,6 +1118,11 @@ path = "src/monte_carlo_methods.rs"
 test = false
 
 [[bin]]
+# https://rosettacode.org/wiki/Multiplication_tables
+name = "multiplication_tables"
+path = "src/multiplication_tables.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Mutual_recursion
 name = "mutual_recursion"
 path = "src/mutual_recursion.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,16 +65,17 @@ with-gtk = ["gtk"]
 with-ncurses = ["ncurses"]
 
 [dependencies]
-regex = "0.1"
 docopt = "0.6"
-time = "0.1"
-rustc-serialize = "0.3"
-rand = "0.3"
-num = "0.1"
-libc = "0.2"
-permutohedron = "0.1"
 eventual = { git = "https://github.com/carllerche/eventual" }
 hyper = "0.6"
+libc = "0.2"
+num = "0.1"
+permutohedron = "0.1"
+rand = "0.3"
+regex = "0.1"
+rustc-serialize = "0.3"
+rust-crypto = "0.2"
+time = "0.1"
 unicode-segmentation = "0.1"
 url = "0.5"
 
@@ -1074,6 +1075,11 @@ path = "src/markov_algorithm.rs"
 # http://rosettacode.org/wiki/Maximum_triangle_path_sum
 name = "maximum_triangle_path_sum"
 path = "src/maximum_triangle_path_sum.rs"
+
+[[bin]]
+# http://rosettacode.org/wiki/MD5
+name = "md5"
+path = "src/md5.rs"
 
 [[bin]]
 # http://rosettacode.org/wiki/MD5/Implementation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1553,6 +1553,11 @@ path = "src/string_interpolation.rs"
 test = false
 
 [[bin]]
+# http://rosettacode.org/wiki/String_interpolation_(included)
+name = "string_interpolation_included"
+path = "src/string_interpolation_included.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Determine_if_a_string_is_numeric
 name = "string_is_numeric"
 path = "src/string_is_numeric.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1297,6 +1297,11 @@ path = "src/read_file_specific_line.rs"
 test = false
 
 [[bin]]
+# http://rosettacode.org/wiki/Real_constants_and_functions
+name = "real_constants_and_functions"
+path = "src/real_constants_and_functions.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Find_limit_of_recursion
 name = "recursion_depth"
 path = "src/recursion_depth.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,6 +167,11 @@ name = "active_object"
 path = "src/active_object.rs"
 
 [[bin]]
+# http://rosettacode.org/wiki/Address_of_a_variable
+name = "address_of_a_variable"
+path = "src/address_of_a_variable.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Arithmetic-geometric_mean
 name = "agm"
 path = "src/agm.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1462,6 +1462,11 @@ name = "singly_linked_list_element_definition"
 path = "src/singly_linked_list/element_definition.rs"
 
 [[bin]]
+# http://rosettacode.org/wiki/Singly-linked_list/Element_insertion
+name = "singly_linked_list_element_insertion"
+path = "src/singly_linked_list/element_insertion.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Sleep
 name = "sleep"
 path = "src/sleep.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -256,6 +256,11 @@ path = "src/assertions.rs"
 test = false
 
 [[bin]]
+# http://rosettacode.org/wiki/Associative_array/Creation
+name = "associative_array_creation"
+path = "src/associative_array/creation.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Atomic_updates
 name = "atomic_updates"
 path = "src/atomic_updates.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -796,6 +796,11 @@ path = "src/hello_world/web_server.rs"
 test = false
 
 [[bin]]
+# http://rosettacode.org/wiki/Here_document
+name = "here_document"
+path = "src/here_document.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Higher-order_functions
 name = "higher_order_functions"
 path = "src/higher_order_functions.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -996,6 +996,11 @@ name = "loops_continue"
 path = "src/loops/continue.rs"
 
 [[bin]]
+# http://rosettacode.org/wiki/Loops/Do-while
+name = "loops_do_while"
+path = "src/loops/do_while.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Loops/Downward_for
 name = "loops_downward_for"
 path = "src/loops/downward_for.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -888,6 +888,11 @@ name = "isaac"
 path = "src/isaac.rs"
 
 [[bin]]
+# https://rosettacode.org/wiki/Iterated_digits_squaring
+name = "iterated_digits_squaring"
+path = "src/iterated_digits_squaring.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Jensen's_Device
 name = "jensens_device"
 path = "src/jensens_device.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -952,6 +952,11 @@ name = "letter_frequency"
 path = "src/letter_frequency.rs"
 
 [[bin]]
+# http://rosettacode.org/wiki/Levenshtein_distance
+name = "levenshtein_distance"
+path = "src/levenshtein_distance.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Levenshtein_distance/Alignment
 name = "levenshtein_distance_alignment"
 path = "src/levenshtein_distance/alignment.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1655,6 +1655,11 @@ name = "use_another_language_to_call_a_function"
 path = "src/use_another_language_to_call_a_function.rs"
 
 [[bin]]
+# http://rosettacode.org/wiki/User_input/Text
+name = "user_input_text"
+path = "src/user_input/text.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Vigen%C3%A8re_cipher
 name = "vigenere"
 path = "src/vigenere.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,11 @@ name = "abc_problem"
 path = "src/abc_problem.rs"
 
 [[bin]]
+# http://rosettacode.org/wiki/Abstract_type
+name = "abstract_type"
+path = "src/abstract_type.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Accumulator_factory
 name = "accumulator_factory"
 path = "src/accumulator_factory.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -276,6 +276,11 @@ name = "averages_mean_angle"
 path = "src/averages/mean_angle.rs"
 
 [[bin]]
+# http://www.rosettacode.org/wiki/Averages/Median
+name = "averages_median"
+path = "src/averages/median.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Averages/Root_mean_square
 name = "averages_root_mean_square"
 path = "src/averages/root_mean_square.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -491,6 +491,11 @@ name = "delete_a_file"
 path = "src/delete_a_file.rs"
 
 [[bin]]
+# http://rosettacode.org/wiki/Determine_if_only_one_instance_is_running
+name = "determine_if_only_one_instance_is_running"
+path = "src/determine_if_only_one_instance_is_running.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Dijkstra's_algorithm
 name = "dijkstras_algorithm"
 path = "src/dijkstras_algorithm.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -481,6 +481,11 @@ path = "src/currying.rs"
 test = false
 
 [[bin]]
+# http://www.rosettacode.org/wiki/Deal_cards_for_FreeCell
+name = "deal_cards_for_freecell"
+path = "src/deal_cards_for_freecell.rs"
+
+[[bin]]
 # http://rosettacode.org/wiki/Delete_a_file
 name = "delete_a_file"
 path = "src/delete_a_file.rs"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://travis-ci.org/Hoverbear/rust-rosetta.png)](https://travis-ci.org/Hoverbear/rust-rosetta)
 [![Coverage Status](https://coveralls.io/repos/Hoverbear/rust-rosetta/badge.svg?branch=master&service=github)](https://coveralls.io/github/Hoverbear/rust-rosetta?branch=master)
 
-A repository for completing [this issue on mozilla/rust](https://github.com/rust-lang/rust/issues/10513). This repository contains minimal working code for many simple (and not so simple) tasks. New contributors and learners of the language are welcome. We will try to work with you to make the code more idiomatic over time.
+A repository for completing [this issue on rust-lang/rust](https://github.com/rust-lang/rust/issues/10513). This repository contains minimal working code for many simple (and not so simple) tasks. New contributors and learners of the language are welcome. We will try to work with you to make the code more idiomatic over time.
 
 > Working on a problem, need some help? Drop by #rust-rosetta on irc.mozilla.org.
 

--- a/build.rs
+++ b/build.rs
@@ -59,13 +59,13 @@ fn main() {
 
 fn check_task_name(path: &Path, line: &str) {
     // Ensure the first line has a URL of the proper form
-    let task_comment = Regex::new(r"// http://rosettacode\.org/wiki/.+").unwrap();
+    let task_comment = Regex::new(r"^// http://rosettacode\.org/wiki/[^#]+$").unwrap();
     if !task_comment.is_match(line) {
         line_error(1,
                    path,
-                   "file does not start with \"// http://rosettacode.org/wiki/<TASK NAME>\"");
+                   "header is missing or malformed. The line should exactly match \
+                   '// http://rosettacode.org/wiki/<TASK NAME>'");
     }
-
 }
 
 fn check(path: &Path) {

--- a/resources/include.rs
+++ b/resources/include.rs
@@ -1,0 +1,1 @@
+println!("Hello from included file!");

--- a/src/abstract_type.rs
+++ b/src/abstract_type.rs
@@ -1,0 +1,41 @@
+// http://rosettacode.org/wiki/Abstract_type
+
+trait Shape {
+    fn area(&self) -> i32;
+
+    fn is_shape(&self) -> bool {
+        true
+    }
+}
+
+struct Square {
+    side_length: i32,
+}
+
+impl Shape for Square {
+    fn area(&self) -> i32 {
+        self.side_length * self.side_length
+    }
+}
+
+fn main() {
+    let square = Square { side_length: 2 };
+    println!("The square's area is: {}", square.area());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Square, Shape};
+
+    #[test]
+    fn area() {
+        let square = Square { side_length: 2 };
+        assert_eq!(square.area(), 4);
+    }
+
+    #[test]
+    fn is_shape() {
+        let square = Square { side_length: 2 };
+        assert!(square.is_shape())
+    }
+}

--- a/src/address_of_a_variable.rs
+++ b/src/address_of_a_variable.rs
@@ -1,0 +1,17 @@
+// http://rosettacode.org/wiki/Address_of_a_variable
+
+fn main() {
+    // Get the memory address of a variable
+    let var = 1_i32;
+    println!("address of var: {:p}", &var);
+
+    // Get the value at a certain memory address
+    let address = &var as *const i32;
+    println!("value at {:p}: {:?}", &address, var);
+
+    // Set the value at a certain memory address
+    unsafe {
+        *(address as *mut i32) = 0;
+        println!("value at {:p}: {:?}", address, var);
+    }
+}

--- a/src/array_length.rs
+++ b/src/array_length.rs
@@ -1,0 +1,6 @@
+// http://rosettacode.org/wiki/Array_length
+
+fn main() {
+    let array = ["foo", "bar", "baz", "biff"];
+    println!("the array has {} elements", array.len());
+}

--- a/src/associative_array/creation.rs
+++ b/src/associative_array/creation.rs
@@ -1,0 +1,12 @@
+// http://rosettacode.org/wiki/Associative_array/Creation
+
+use std::collections::HashMap;
+
+fn main() {
+    let mut olympic_medals = HashMap::new();
+    olympic_medals.insert("United States", (1072, 859, 749));
+    olympic_medals.insert("Soviet Union", (473, 376, 355));
+    olympic_medals.insert("Great Britain", (246, 276, 284));
+    olympic_medals.insert("Germany", (252, 260, 270));
+    println!("{:?}", olympic_medals);
+}

--- a/src/averages/median.rs
+++ b/src/averages/median.rs
@@ -1,0 +1,26 @@
+// http://rosettacode.org/wiki/Averages/Median
+
+fn median(samples: &[f64]) -> f64 {
+    let mut xs = samples.iter().cloned().collect::<Vec<_>>();
+    xs.sort_by(|x, y| x.partial_cmp(y).unwrap());
+
+    let n = xs.len();
+    if n % 2 == 0 {
+        (xs[n / 2] + xs[(n / 2) + 1]) / 2.0
+    } else {
+        xs[n / 2]
+    }
+}
+
+fn main() {
+    let mut nums = vec![2., 3., 5., 0., 9., 82., 353., 32., 12.];
+    println!("{:?}", median(&mut nums))
+}
+
+mod tests {
+    #[test]
+    fn median() {
+        let mut nums = vec![2., 3., 5., 0., 9., 82., 353., 32., 12.];
+        assert_eq!(super::median(&mut nums), 9_f64);
+    }
+}

--- a/src/caesar_cipher.rs
+++ b/src/caesar_cipher.rs
@@ -1,0 +1,62 @@
+// http://rosettacode.org/wiki/Caesar_cipher
+
+use std::io::{self, Write};
+use std::fmt::Display;
+use std::{env, process};
+
+fn main() {
+    let shift = env::args()
+                    .nth(1)
+                    .unwrap_or_else(|| exit_err("No shift provided", 2))
+                    .parse::<u8>()
+                    .unwrap_or_else(|e| exit_err(e, 3));
+
+    let plain = get_input().unwrap_or_else(|e| exit_err(&e, e.raw_os_error().unwrap_or(-1)));
+
+    let cipher = cipher(&plain, shift);
+
+    println!("Cipher text: {}", cipher.trim());
+}
+
+fn cipher(input: &str, shift: u8) -> String {
+    input.chars()
+         .map(|c| {
+             let case = if c.is_uppercase() {
+                 b'A'
+             } else {
+                 b'a'
+             };
+
+             if c.is_alphabetic() {
+                 (((c as u8 - case + shift) % 26) + case) as char
+             } else {
+                 c
+             }
+
+         })
+         .collect()
+}
+
+fn get_input() -> io::Result<String> {
+    print!("Plain text:  ");
+    try!(io::stdout().flush());
+
+    let mut buf = String::new();
+    try!(io::stdin().read_line(&mut buf));
+    Ok(buf)
+}
+
+fn exit_err<T: Display>(msg: T, code: i32) -> ! {
+    writeln!(&mut io::stderr(), "ERROR: {}", msg).unwrap();
+    process::exit(code);
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn encode() {
+        let original = "The five boxing wizards jump quickly";
+        let encoded = "Wkh ilyh eralqj zlcdugv mxps txlfnob";
+        assert_eq!(super::cipher(original, 3), encoded);
+    }
+}

--- a/src/circles_of_given_radius_through_two_points.rs
+++ b/src/circles_of_given_radius_through_two_points.rs
@@ -1,0 +1,104 @@
+// http://rosettacode.org/wiki/Circles_of_given_radius_through_two_points
+
+//! Translation of C.
+
+use std::fmt;
+
+#[derive(Clone,Copy)]
+struct Point {
+    x: f64,
+    y: f64,
+}
+
+fn distance(p1: Point, p2: Point) -> f64 {
+    ((p1.x - p2.x).powi(2) + (p1.y - p2.y).powi(2)).sqrt()
+}
+
+impl fmt::Display for Point {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "({:.4}, {:.4})", self.x, self.y)
+    }
+}
+
+fn describe_circle(p1: Point, p2: Point, r: f64) {
+    let sep = distance(p1, p2);
+
+    if sep == 0. {
+        if r == 0. {
+            println!("No circles can be drawn through {}", p1);
+        } else {
+            println!("Infinitely many circles can be drawn through {}", p1);
+        }
+    } else if sep == 2.0 * r {
+        println!("Given points are opposite ends of a diameter of the circle with center \
+                  ({:.4},{:.4}) and r {:.4}",
+                 (p1.x + p2.x) / 2.0,
+                 (p1.y + p2.y) / 2.0,
+                 r);
+    } else if sep > 2.0 * r {
+        println!("Given points are farther away from each other than a diameter of a circle with \
+                  r {:.4}",
+                 r);
+    } else {
+        let mirror_dist = (r.powi(2) - (sep / 2.0).powi(2)).sqrt();
+
+        println!("Two circles are possible.");
+        println!("Circle C1 with center ({:.4}, {:.4}), r {:.4} and Circle C2 with center \
+                  ({:.4}, {:.4}), r {:.4}",
+                 ((p1.x + p2.x) / 2.0) + mirror_dist * (p1.y - p2.y) / sep,
+                 (p1.y + p2.y) / 2.0 + mirror_dist * (p2.x - p1.x) / sep,
+                 r,
+                 (p1.x + p2.x) / 2.0 - mirror_dist * (p1.y - p2.y) / sep,
+                 (p1.y + p2.y) / 2.0 - mirror_dist * (p2.x - p1.x) / sep,
+                 r);
+    }
+}
+
+fn main() {
+    let points = vec![(Point {
+                          x: 0.1234,
+                          y: 0.9876,
+                      },
+                       Point {
+                          x: 0.8765,
+                          y: 0.2345,
+                      }),
+                      (Point {
+                          x: 0.0000,
+                          y: 2.0000,
+                      },
+                       Point {
+                          x: 0.0000,
+                          y: 0.0000,
+                      }),
+                      (Point {
+                          x: 0.1234,
+                          y: 0.9876,
+                      },
+                       Point {
+                          x: 0.1234,
+                          y: 0.9876,
+                      }),
+                      (Point {
+                          x: 0.1234,
+                          y: 0.9876,
+                      },
+                       Point {
+                          x: 0.8765,
+                          y: 0.2345,
+                      }),
+                      (Point {
+                          x: 0.1234,
+                          y: 0.9876,
+                      },
+                       Point {
+                          x: 0.1234,
+                          y: 0.9876,
+                      })];
+    let radii: Vec<f64> = vec![2.0, 1.0, 2.0, 0.5, 0.0];
+
+    for (p, r) in points.into_iter().zip(radii.into_iter()) {
+        println!("\nPoints: ({}, {}), Radius: {:.4}", p.0, p.1, r);
+        describe_circle(p.0, p.1, r);
+    }
+}

--- a/src/collections.rs
+++ b/src/collections.rs
@@ -1,0 +1,160 @@
+// http://rosettacode.org/wiki/Collections
+
+//! Examples of various Rust collections. Contains both original examples and those taken from the
+//! standard API documentation.
+
+use std::collections::{BinaryHeap, BTreeMap, HashMap, HashSet, LinkedList, VecDeque};
+
+fn main() {
+    // Stack-allocated collections
+    // ---------------------------
+
+    // Array
+    //
+    // Arrays ([T]) are stack allocated, fixed size collections of items of the same type.
+    let a = [1u8, 2, 3, 4, 5]; // a is of type [u8; 5];
+    let b = [0; 256]; // Equivalent to `let b = [0, 0, 0, 0, 0, 0... repeat 256 times]`
+    assert_eq!(a.len(), 5);
+    assert_eq!(b.len(), 256);
+
+    // Slice
+    //
+    // Slices (&[T]) are dynamically sized views into contiguous sequences (arrays, vectors,
+    // strings)
+    let array = [1, 2, 3, 4, 5];
+    let slice = &array[0..2];
+    println!("{:?}", slice);    // Output: [1, 2]
+
+    // String slice
+    //
+    // String slices are (str) are slices of Unicode characters. Plain strs are almost never seen
+    // in Rust. Instead either heap-allocated Strings or borrowed string slices (&str which is
+    // basically equivalent to a slice of bytes: &[u8]) are more often used. It should be noted
+    // that strings are not indexable as they are UTF-8 (meaning that characters are not
+    // necessarily of a fixed size) however iterators can be created over codepoints or graphemes.
+    let string = "this is a string slice";
+    println!("{}", string);
+
+    // Heap-allocated collections
+    // --------------------------
+
+    // Vector
+    //
+    // Vectors (Vec<T>) are a growable list type. According to the Rust documentation, you want to
+    // use a Vector if:
+    // - You want to collect items up to be processed or sent elsewhere later, and don't care about
+    //   any properties of the actual values being stored.
+    // - You want a sequence of elements in a particular order, and will only be appending to (or
+    //   near) the end.
+    // - You want a stack.
+    // - You want a resizable array.
+    // - You want a heap-allocated array.
+    let mut v1 = Vec::new();
+    v1.push(1);
+    v1.push(2);
+    v1.push(3);
+
+    // Or (mostly) equivalently via a convenient macro in the standard library,
+    let v2 = vec![1, 2, 3];
+    assert_eq!(v1, v2);
+
+    // String
+    //
+    // Strings are growable strings stored as a UTF-8 buffer which are just Vec<u8>s under the
+    // hood. Like strs, they are not indexable (for the same reasons) but iterators can be created
+    // over the graphemes, codepoints or bytes therein.
+    let x = "abc";      // x is of type &str (a borrowed string slice)
+    let s1 = String::from(x);
+    assert_eq!(x, &s1);
+
+    // or alternatively,
+    let s2 = x.to_owned();
+    assert_eq!(s1, s2);
+
+    // VecDequeue
+    //
+    // A growable ring buffer. According to the Rust documentation you should use VecDequeue<T>
+    // when:
+    // - You want a Vec that supports efficient insertion at both ends of the sequence.
+    // - You want a queue.
+    // - You want a double-ended queue (deque).
+    let mut deque = VecDeque::new();
+    deque.push_back(3);
+    deque.push_back(4);
+    deque.push_back(5);
+    assert_eq!(deque.get(1), Some(&4));
+
+    // Linked List
+    //
+    // A doubly-linked list. According to the Rust documentation, you should use it when:
+    // - You want a Vec or VecDeque of unknown size, and can't tolerate amortization.
+    // - You want to efficiently split and append lists.
+    // - You are absolutely certain you really, truly, want a doubly linked list.
+    let mut a = LinkedList::new();
+    let mut b = LinkedList::new();
+    a.push_back(1);
+    a.push_back(2);
+    b.push_back(3);
+    b.push_back(4);
+
+    // A constant-time and -memory operation.
+    a.append(&mut b);
+
+    for e in &a {
+        println!("{}", e);      // prints 1, then 2, then 3, then 4
+    }
+
+    // HashMap
+    //
+    // A hash map implementation which uses linear probing with Robin Hood bucket stealing.
+    // According to the Rust documentation, you should use it when:
+    // - You want to associate arbitrary keys with an arbitrary value.
+    // - You want a cache.
+    // - You want a map, with no extra functionality.
+    let mut map = HashMap::new();
+    map.insert(1, "a");
+    map.insert(2, "b");
+    map.insert(3, "c");
+    for (key, value) in map {
+        println!("key: {}, value: {}", key, value);
+    }
+
+    // BTreeMap
+    //
+    // A map based on a B-Tree. According to the Rust documentation, you should use it when:
+    // - You're interested in what the smallest or largest key-value pair is.
+    // - You want to find the largest or smallest key that is smaller or larger than something.
+    // - You want to be able to get all of the entries in order on-demand.
+    // - You want a sorted map.
+    let mut map = BTreeMap::new();
+    map.insert(1, "a");
+    map.insert(2, "b");
+    map.insert(3, "c");
+    assert_eq!(map.get(&1), Some(&"a"));
+
+    // HashSet/BTreeSet
+    //
+    // Set implementations that use an empty tuple () as the value of their respective maps (and
+    // implement different methods). They should be used when:
+    // - You just want to remember which keys you've seen.
+    // - There is no meaningful value to associate with your keys.
+    // - You just want a set.
+    let mut set = HashSet::new();
+    set.insert(1);
+    set.insert(2);
+    set.insert(3);
+    set.insert(2);
+    assert_eq!(set.len(), 3);
+
+    // BinaryHeap
+    //
+    // A priority queue implemented with a binary heap. You should use it when
+    // - You want to store a bunch of elements, but only ever want to process the "biggest" or
+    //   "most important" one at any given time.
+    // - You want a priority queue.
+    let mut heap = BinaryHeap::new();
+    heap.push(1);
+    heap.push(5);
+    heap.push(2);
+    assert_eq!(heap.peek(), Some(&5));
+}

--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -1,0 +1,46 @@
+// http://rosettacode.org/wiki/Combinations
+
+use std::fmt::Display;
+
+fn comb<T>(arr: &[T], n: u32)
+    where T: Display
+{
+    let mut incl_arr = vec![false; arr.len()];
+    comb_intern(arr, n as usize, &mut incl_arr, 0);
+}
+
+fn comb_intern<T>(arr: &[T], n: usize, incl_arr: &mut [bool], index: usize)
+    where T: Display
+{
+    if arr.len() < n + index {
+        return;
+    }
+    if n == 0 {
+        let it = arr.iter().zip(incl_arr.iter()).filter_map(|(val, incl)| {
+            if *incl {
+                Some(val)
+            } else {
+                None
+            }
+        });
+        for val in it {
+            print!("{} ", *val);
+        }
+        print!("\n");
+        return;
+    }
+
+    incl_arr[index] = true;
+    comb_intern(arr, n - 1, incl_arr, index + 1);
+    incl_arr[index] = false;
+
+    comb_intern(arr, n, incl_arr, index + 1);
+}
+
+fn main() {
+    let vec1 = vec![1, 2, 3, 4, 5];
+    comb(&vec1, 3);
+
+    let vec2 = vec!["A", "B", "C", "D", "E"];
+    comb(&vec2, 3);
+}

--- a/src/compound_data_type.rs
+++ b/src/compound_data_type.rs
@@ -1,0 +1,29 @@
+// http://rosettacode.org/wiki/Compound_data_type
+
+//! There are three kinds of `structs` in Rust, two of which would be suitable to represent a
+//! point.
+
+/// C-like struct.
+///
+/// Defines a generic struct where x and y can be of any type `T`.
+struct Point<T> {
+    x: T,
+    y: T,
+}
+
+/// Tuple struct
+///
+/// These are basically just named tuples.
+struct TuplePoint<T>(T, T);
+
+fn main() {
+    let p1 = Point { x: 1.0, y: 2.5 };    // p is of type Point<f64>
+    println!("{}, {}", p1.x, p1.y);
+
+    let p2 = TuplePoint(1.0, 2.5);
+    println!("{}, {}", p2.0, p2.1);
+
+    // A plain tuple may also be used.
+    let p3 = (1.0, 2.5);
+    println!("{}, {}", p3.0, p3.1)
+}

--- a/src/deal_cards_for_freecell.rs
+++ b/src/deal_cards_for_freecell.rs
@@ -1,0 +1,64 @@
+// http://rosettacode.org/wiki/Deal_cards_for_FreeCell
+
+//! Based on JavaScript.
+
+struct MSVCRandGen {
+    seed: u32,
+}
+
+impl MSVCRandGen {
+    fn rand(&mut self) -> u32 {
+        self.seed = (self.seed.wrapping_mul(214013).wrapping_add(2531011)) % 0x80000000;
+        assert!(self.seed >> 16 < 32768);
+        (self.seed >> 16) & 0x7FFF
+    }
+    fn max_rand(&mut self, mymax: u32) -> u32 {
+        self.rand() % mymax
+    }
+    fn shuffle<T>(&mut self, deck: &mut [T]) {
+        if deck.len() > 0 {
+            let mut i = (deck.len() as u32) - 1;
+            while i > 0 {
+                let j = self.max_rand(i + 1);
+                deck.swap(i as usize, j as usize);
+                i = i - 1;
+            }
+        }
+    }
+}
+
+fn deal_ms_fc_board(seed: u32) -> String {
+    let mut randomizer = MSVCRandGen { seed: seed };
+    let num_cols = 8;
+
+    let mut columns = vec![Vec::new(); num_cols];
+    let mut deck: Vec<_> = (0..4 * 13).collect();
+
+    let rank_strings: Vec<char> = "A23456789TJQK".chars().collect();
+    let suit_strings: Vec<char> = "CDHS".chars().collect();
+
+    randomizer.shuffle(&mut deck);
+
+    deck.reverse();
+
+    for i in 0..52 {
+        columns[i % num_cols].push(deck[i]);
+    }
+
+    let render_card = |card: usize| -> String {
+        let (suit, rank) = (card % 4, card / 4);
+        format!("{}{}", rank_strings[rank], suit_strings[suit])
+    };
+
+    let render_column = |col: Vec<usize>| -> String {
+        format!(": {}\n",
+                col.into_iter().map(&render_card).collect::<Vec<String>>().join(" "))
+    };
+
+    columns.into_iter().map(render_column).collect::<Vec<_>>().join("")
+}
+
+fn main() {
+    let arg: u32 = std::env::args().nth(1).and_then(|n| n.parse().ok()).expect("I need a number.");
+    print!("{}", deal_ms_fc_board(arg));
+}

--- a/src/determine_if_only_one_instance_is_running.rs
+++ b/src/determine_if_only_one_instance_is_running.rs
@@ -1,0 +1,25 @@
+// http://rosettacode.org/wiki/Determine_if_only_one_instance_is_running
+
+use std::net::TcpListener;
+
+fn create_app_lock(port: u16) -> TcpListener {
+    match TcpListener::bind(("0.0.0.0", port)) {
+        Ok(socket) => socket,
+        Err(_) => {
+            panic!("Couldn't lock port {}: another instance already running?",
+                   port);
+        }
+    }
+}
+
+fn remove_app_lock(socket: TcpListener) {
+    drop(socket);
+}
+
+fn main() {
+    let lock_socket = create_app_lock(12345);
+    // ...
+    // your code here
+    // ...
+    remove_app_lock(lock_socket);
+}

--- a/src/doubly_linked_list/element_definition.rs
+++ b/src/doubly_linked_list/element_definition.rs
@@ -1,0 +1,63 @@
+// http://rosettacode.org/wiki/Doubly-linked_list/Element_definition
+
+//! Doubly linked lists present a problem in Rust due to its ownership model. There cannot be two
+//! mutable references to the same object, so what are we to do? Below are the relevant lines (with
+//! added comments) from the `std` implementation ([Documentation][doc] [Source][src]).
+//!
+//! In order to circumvent the multiple mutable references, raw C-like pointers are used. Note that
+//! these cannot be dereferenced with guaranteed safety and thus dereferencing is relegated to
+//! `unsafe {}` blocks.
+//!
+//! [doc]: https://doc.rust-lang.org/std/collections/struct.LinkedList.html
+//! [src]: https://github.com/rust-lang/rust/blob/master/src/libcollections/linked_list.rs
+
+#![allow(dead_code)]
+
+use std::ptr;
+
+/// User-facing implementation
+pub struct LinkedList<T> {
+    length: usize,
+    list_head: Link<T>,
+    list_tail: Rawlink<Node<T>>,
+}
+
+impl<T> LinkedList<T> {
+    pub fn new() -> LinkedList<T> {
+        LinkedList {
+            length: 0,
+            list_head: None,
+            list_tail: Rawlink { p: ptr::null_mut() },
+        }
+    }
+}
+
+/// Type definition
+type Link<T> = Option<Box<Node<T>>>;
+
+/// Pointer is wrapped in struct so that Option-like methods can be added to it later (wrappers
+/// around NULL checks)
+struct Rawlink<T> {
+    /// Raw mutable pointer
+    p: *mut T,
+}
+
+struct Node<T> {
+    next: Link<T>,
+    prev: Rawlink<Node<T>>,
+    value: T,
+}
+
+fn main() {
+    // Note: you can just import the standard definition.
+    use std::collections;
+
+    // Doubly linked list containing 32-bit integers
+    let list1 = collections::LinkedList::<i32>::new();
+
+    // Doubly linked list containing 32-bit integers
+    let list2 = self::LinkedList::<i32>::new();
+
+    drop(list1);
+    drop(list2);
+}

--- a/src/doubly_linked_list/element_insertion.rs
+++ b/src/doubly_linked_list/element_insertion.rs
@@ -1,0 +1,103 @@
+// http://rosettacode.org/wiki/Doubly-linked_list/Element_insertion
+
+//! This expands upon the implementation defined in [Doubly-linked list/Element
+//! definition#The_behind-the-scenes_implementation][element definition] and consists of the
+//! relevant lines from the `LinkedList` implementation in the Rust standard library.
+//!
+//! [element definition]: http://rosettacode.org/wiki/Doubly-linked_list/Element_definition
+
+#![allow(dead_code)]
+
+use std::mem;
+use std::ptr;
+
+pub struct LinkedList<T> {
+    length: usize,
+    list_head: Link<T>,
+    list_tail: Rawlink<Node<T>>,
+}
+
+type Link<T> = Option<Box<Node<T>>>;
+
+struct Rawlink<T> {
+    p: *mut T,
+}
+
+struct Node<T> {
+    next: Link<T>,
+    prev: Rawlink<Node<T>>,
+    value: T,
+}
+
+impl<T> Node<T> {
+    fn new(v: T) -> Node<T> {
+        Node {
+            value: v,
+            next: None,
+            prev: Rawlink::none(),
+        }
+    }
+}
+
+impl<T> Rawlink<T> {
+    fn none() -> Self {
+        Rawlink { p: ptr::null_mut() }
+    }
+
+    fn some(n: &mut T) -> Rawlink<T> {
+        Rawlink { p: n }
+    }
+}
+
+impl<'a, T> From<&'a mut Link<T>> for Rawlink<Node<T>> {
+    fn from(node: &'a mut Link<T>) -> Self {
+        match node.as_mut() {
+            None => Rawlink::none(),
+            Some(ptr) => Rawlink::some(ptr),
+        }
+    }
+}
+
+fn link_no_prev<T>(mut next: Box<Node<T>>) -> Link<T> {
+    next.prev = Rawlink::none();
+    Some(next)
+}
+
+impl<T> LinkedList<T> {
+    pub fn new() -> LinkedList<T> {
+        LinkedList {
+            length: 0,
+            list_head: None,
+            list_tail: Rawlink { p: ptr::null_mut() },
+        }
+    }
+
+    #[inline]
+    fn push_front_node(&mut self, mut new_head: Box<Node<T>>) {
+        match self.list_head {
+            None => {
+                self.list_head = link_no_prev(new_head);
+                self.list_tail = Rawlink::from(&mut self.list_head);
+            }
+            Some(ref mut head) => {
+                new_head.prev = Rawlink::none();
+                head.prev = Rawlink::some(&mut *new_head);
+                mem::swap(head, &mut new_head);
+                head.next = Some(new_head);
+            }
+        }
+        self.length += 1;
+    }
+    pub fn push_front(&mut self, elt: T) {
+        self.push_front_node(Box::new(Node::new(elt)));
+    }
+}
+
+fn main() {
+    use std::collections;
+    let mut list1 = collections::LinkedList::new();
+    list1.push_front(8);
+
+    let mut list2 = LinkedList::new();
+    list2.push_front(8);
+}

--- a/src/enforced_immutability.rs
+++ b/src/enforced_immutability.rs
@@ -1,0 +1,26 @@
+// http://rosettacode.org/wiki/Enforced_immutability
+
+#![allow(unused_variables)]
+
+fn main() {
+    // Rust let bindings are immutable by default.
+    let x = 3;
+    // This will raise a compiler error:
+    // x += 2;  //~ ERROR cannot assign to immutable borrowed content `*y`
+
+    // You must declare a variable mutable explicitly:
+    let mut x = 3;
+
+    // Similarly, references are immutable by default e.g.
+    // The following lines would raise a compiler error. Even though x is mutable, y is an
+    // immutable reference.
+    // let y = &x;
+    // *y += 2; //~ ERROR cannot borrow `x` as mutable because it is also borrowed as immutable
+
+    let y = &mut x;
+    *y += 2;    // Works
+
+    // Note that though y is now a mutable reference, y itself is still immutable e.g.
+    // let mut z = 5;
+    // y = &mut z; //~ ERROR re-assignment of immutable variable `y`
+}

--- a/src/even_or_odd.rs
+++ b/src/even_or_odd.rs
@@ -1,0 +1,13 @@
+// http://rosettacode.org/wiki/Even_or_odd
+
+#![allow(unused_variables)]
+
+fn main() {
+    // Checking the last significant digit:
+    let is_odd = |x: i32| x & 1 == 1;
+    let is_even = |x: i32| x & 1 == 0;
+
+    // Using modular congruences:
+    let is_odd = |x: i32| x % 2 != 0;
+    let is_even = |x: i32| x % 2 == 0;
+}

--- a/src/greatest_subsequential_sum.rs
+++ b/src/greatest_subsequential_sum.rs
@@ -1,0 +1,40 @@
+// http://rosettacode.org/wiki/Greatest_subsequential_sum
+
+#![feature(iter_arith)]
+
+use std::ops::Range;
+
+fn greatest_subsequential_sum(nums: &[i32]) -> (i32, Range<usize>) {
+    let mut max = 0;
+    let mut boundaries = 0..0;
+
+    for length in 0..nums.len() {
+        for start in 0..nums.len() - length {
+            let sum = (&nums[start..start + length]).iter().sum();
+            if sum > max {
+                max = sum;
+                boundaries = start..start + length;
+            }
+        }
+    }
+
+    (max, boundaries)
+}
+
+fn main() {
+    let nums = [1, 2, 39, 34, 20, -20, -16, 35, 0];
+
+    let (max, boundaries) = greatest_subsequential_sum(&nums);
+
+    println!("Max subsequence sum: {} for {:?}", max, &nums[boundaries]);;
+}
+
+#[test]
+fn subsequential_sum() {
+    let nums = [1, 2, 39, 34, 20, -20, -16, 35, 0];
+
+    let (max, boundaries) = greatest_subsequential_sum(&nums);
+
+    assert_eq!(max, 96);
+    assert_eq!(&nums[boundaries], &[1, 2, 39, 34, 20]);
+}

--- a/src/guess_the_number/with_feedback_player.rs
+++ b/src/guess_the_number/with_feedback_player.rs
@@ -1,0 +1,44 @@
+// http://rosettacode.org/wiki/Guess_the_number/With_feedback_(player)
+
+use std::io::stdin;
+
+const MIN: isize = 1;
+const MAX: isize = 100;
+
+fn main() {
+    loop {
+        let mut min = MIN;
+        let mut max = MAX;
+        let mut num_guesses = 1;
+        println!("Please think of a number between {} and {}", min, max);
+        loop {
+            let guess = (min + max) / 2;
+            println!("Is it {}?", guess);
+            println!("(type h if my guess is too high, l if too low, e if equal and q to quit)");
+
+            let mut line = String::new();
+            stdin().read_line(&mut line).unwrap();
+            match Some(line.chars().next().unwrap().to_uppercase().next().unwrap()) {
+                Some('H') => {
+                    max = guess - 1;
+                    num_guesses += 1;
+                }
+                Some('L') => {
+                    min = guess + 1;
+                    num_guesses += 1;
+                }
+                Some('E') => {
+                    if num_guesses == 1 {
+                        println!("\n*** That was easy! Got it in one guess! ***\n");
+                    } else {
+                        println!("\n*** I knew it! Got it in only {} guesses! ***\n",
+                                 num_guesses);
+                    }
+                    break;
+                }
+                Some('Q') => return,
+                _ => println!("Sorry, I didn't quite get that. Please try again."),
+            }
+        }
+    }
+}

--- a/src/hello_world/graphical.rs
+++ b/src/hello_world/graphical.rs
@@ -1,0 +1,35 @@
+// http://rosettacode.org/wiki/Hello_world/Graphical
+
+#[cfg(feature = "with-gtk")]
+mod graphical {
+    extern crate gtk;
+
+    use self::gtk::traits::*;
+    use self::gtk::{Inhibit, WidgetSignals, Window, WindowType, WindowPosition};
+
+    pub fn hello_world() {
+        gtk::init().unwrap();
+        let window = Window::new(WindowType::Toplevel);
+
+        window.set_title("Hello World!");
+        window.set_border_width(10);
+        window.set_position(WindowPosition::Center);
+        window.set_default_size(350, 70);
+
+        window.connect_delete_event(|_, _| {
+            gtk::main_quit();
+            Inhibit(false)
+        });
+
+        window.show_all();
+        gtk::main();
+    }
+}
+
+#[cfg(feature = "with-gtk")]
+fn main() {
+    graphical::hello_world();
+}
+
+#[cfg(not(feature = "with-gtk"))]
+fn main() {}

--- a/src/hello_world/line_printer.rs
+++ b/src/hello_world/line_printer.rs
@@ -1,0 +1,9 @@
+// http://rosettacode.org/wiki/Hello_world/Line_printer
+
+use std::fs::File;
+use std::io::Write;
+
+fn main() {
+    let mut file = File::open("/dev/lp0").unwrap();
+    write!(file, "Hello World!").unwrap();
+}

--- a/src/here_document.rs
+++ b/src/here_document.rs
@@ -1,0 +1,10 @@
+// http://rosettacode.org/wiki/Here_document
+
+fn main() {
+    // Similar to C++, Rust offers raw strings:
+    let x = r#"
+        This is a "raw string literal," roughly equivalent to a heredoc.
+    "#;
+
+    println!("{}", x);
+}

--- a/src/include_a_file.rs
+++ b/src/include_a_file.rs
@@ -1,0 +1,19 @@
+// http://rosettacode.org/wiki/Include_a_file
+
+// The compiler will include either a `test.rs` or `test/mod.rs` (if the first one doesn't exist)
+// file.
+mod hello_world;
+
+// Additionally, third-party libraries (called `crates` in Rust) can be declared thusly:
+extern crate url;
+
+use url::Url;
+
+fn main() {
+    // Use a struct included from an external crate.
+    println!("{:?}", Url::parse("http://rosettacode.org").unwrap());
+
+    // Though uncommon, it is also possible to include source directly from files with the
+    // `include!` macro.
+    include!(concat!(env!("CARGO_MANIFEST_DIR"), "/resources/include.rs"));
+}

--- a/src/integer_comparison.rs
+++ b/src/integer_comparison.rs
@@ -1,0 +1,19 @@
+// http://rosettacode.org/wiki/Integer_comparison
+
+use std::io::{self, BufRead};
+
+fn main() {
+    let reader = io::stdin();
+    let lines = reader.lock().lines().take(2);
+    let nums = lines.map(|string| string.unwrap().trim().parse().unwrap())
+                    .collect::<Vec<i32>>();
+    let a = nums[0];
+    let b = nums[1];
+    if a < b {
+        println!("{} is less than {}", a, b)
+    } else if a == b {
+        println!("{} equals {}", a, b)
+    } else if a > b {
+        println!("{} is greater than {}", a, b)
+    };
+}

--- a/src/iterated_digits_squaring.rs
+++ b/src/iterated_digits_squaring.rs
@@ -1,0 +1,55 @@
+// http://rosettacode.org/wiki/Iterated_digits_squaring
+
+//! These are two naive solutions, one with lots of redundant calculations (memoizationless
+//! recursion) and one with a few precomputed values. All digit square sums are no greater than 648
+//! for numbers < 100_000_000.
+//!
+//! Both are slow algorithms, however, Rust is among faster languages, so this doesn't take minutes
+//! or hours.
+
+fn digit_square_sum(mut num: usize) -> usize {
+    let mut sum = 0;
+    while num != 0 {
+        sum += (num % 10).pow(2);
+        num /= 10;
+    }
+    sum
+}
+
+fn last_in_chain(num: usize) -> usize {
+    match num {
+        0 => 0,
+        1 | 89 => num,
+        _ => last_in_chain(digit_square_sum(num)),
+    }
+}
+
+fn main() {
+    let count = (1..100_000_000).filter(|&n| last_in_chain(n) == 89).count();
+    println!("{}", count);
+
+    let precomputed = (0..649).map(|n| last_in_chain(n)).collect::<Vec<_>>();
+    let count = (1..100_000_000).filter(|&n| precomputed[digit_square_sum(n)] == 89).count();
+    println!("{}", count);
+}
+
+/// Ignore these tests because they're pretty expensive on a non-release build.
+#[cfg(test)]
+mod tests {
+    use super::{digit_square_sum, last_in_chain};
+
+    #[test]
+    #[ignore]
+    fn naive() {
+        let count = (1..100_000_000).filter(|&n| last_in_chain(n) == 89).count();
+        assert_eq!(count, 85744333);
+    }
+
+    #[test]
+    #[ignore]
+    fn precomputation() {
+        let precomputed = (0..649).map(|n| last_in_chain(n)).collect::<Vec<_>>();
+        let count = (1..100_000_000).filter(|&n| precomputed[digit_square_sum(n)] == 89).count();
+        assert_eq!(count, 85744333);
+    }
+}

--- a/src/keyboard_input/obtain_a_y_or_n_response.rs
+++ b/src/keyboard_input/obtain_a_y_or_n_response.rs
@@ -1,0 +1,34 @@
+// http://rosettacode.org/wiki/Keyboard_input/Obtain_a_Y_or_N_response
+
+#[cfg(feature = "ncurses")]
+extern crate ncurses;
+
+#[cfg(feature = "ncurses")]
+fn main() {
+    ncurses::initscr();
+    loop {
+        ncurses::printw("Yes or no? ");
+        ncurses::refresh();
+
+        match ncurses::getch() as u8 as char {
+            'Y' | 'y' => {
+                ncurses::printw("You said yes!");
+            }
+            'N' | 'n' => {
+                ncurses::printw("You said no!");
+            }
+            _ => {
+                ncurses::printw("Try again!\n");
+                continue;
+            }
+        }
+
+        break;
+    }
+
+    ncurses::refresh();
+    ncurses::endwin();
+}
+
+#[cfg(not(feature = "ncurses"))]
+fn main() {}

--- a/src/levenshtein_distance.rs
+++ b/src/levenshtein_distance.rs
@@ -1,0 +1,41 @@
+// http://rosettacode.org/wiki/Levenshtein_distance
+
+fn levenshtein_distance(word1: &str, word2: &str) -> usize {
+    let word1_length = word1.len() + 1;
+    let word2_length = word2.len() + 1;
+
+    let mut matrix = vec![vec![0]];
+
+    for i in 1..word1_length {
+        matrix[0].push(i);
+    }
+    for j in 1..word2_length {
+        matrix.push(vec![j]);
+    }
+
+    for j in 1..word2_length {
+        for i in 1..word1_length {
+            let x: usize = if word1.chars().nth(i - 1) == word2.chars().nth(j - 1) {
+                matrix[j - 1][i - 1]
+            } else {
+                let min_distance = [matrix[j][i - 1], matrix[j - 1][i], matrix[j - 1][i - 1]];
+                *min_distance.iter().min().unwrap() + 1
+            };
+
+            matrix[j].push(x);
+        }
+    }
+
+    matrix[word2_length - 1][word1_length - 1]
+}
+
+fn main() {
+    println!("{}", levenshtein_distance("kitten", "sitting"));
+    println!("{}", levenshtein_distance("saturday", "sunday"));
+    println!("{}", levenshtein_distance("rosettacode", "raisethysword"));
+}
+
+#[test]
+fn test_levenshtein_distance() {
+    assert_eq!(levenshtein_distance("kitten", "sitting"), 3);
+}

--- a/src/loops/do_while.rs
+++ b/src/loops/do_while.rs
@@ -1,0 +1,17 @@
+// http://rosettacode.org/wiki/Loops/Do-while
+
+//! Rust does not have a `do...while` loop. Instead, the keyword `loop` is used with a termination
+//! condition.
+
+fn main() {
+    let mut x = 0;
+
+    loop {
+        x += 1;
+        println!("{}", x);
+
+        if x % 6 == 0 {
+            break;
+        }
+    }
+}

--- a/src/maximum_triangle_path_sum.rs
+++ b/src/maximum_triangle_path_sum.rs
@@ -1,0 +1,68 @@
+// http://rosettacode.org/wiki/Maximum_triangle_path_sum
+
+use std::cmp;
+
+const TRIANGLE: &'static str = r"55
+94 48
+95 30 96
+77 71 26 67
+97 13 76 38 45
+07 36 79 16 37 68
+48 07 09 18 70 26 06
+18 72 79 46 59 79 29 90
+20 76 87 11 32 07 07 49 18
+27 83 58 35 71 11 25 57 29 85
+14 64 36 96 27 11 58 56 92 18 55
+02 90 03 60 48 49 41 46 33 36 47 23
+92 50 48 02 36 59 42 79 72 20 82 77 42
+56 78 38 80 39 75 02 71 66 66 01 03 55 72
+44 25 67 84 71 67 11 61 40 57 58 89 40 56 36
+85 32 25 85 57 48 84 35 47 62 17 01 01 99 89 52
+06 71 28 75 94 48 37 10 23 51 06 48 53 18 74 98 15
+27 02 92 23 08 71 76 84 15 52 92 63 81 10 44 10 69 93";
+
+fn max_path(vector: &mut Vec<Vec<u32>>) -> u32 {
+    while vector.len() > 1 {
+        let last = vector.pop().unwrap();
+        let ante = vector.pop().unwrap();
+
+        let mut new: Vec<u32> = Vec::new();
+
+        for (i, value) in ante.iter().enumerate() {
+            new.push(cmp::max(last[i], last[i + 1]) + value);
+        }
+
+        vector.push(new);
+    }
+
+    vector[0][0]
+}
+
+fn main() {
+    let mut vector = TRIANGLE.split("\n")
+                             .map(|x| {
+                                 x.split(" ")
+                                  .map(|s: &str| s.parse::<u32>().unwrap())
+                                  .collect::<Vec<u32>>()
+                             })
+                             .collect::<Vec<Vec<u32>>>();
+
+    let max_value = max_path(&mut vector);
+
+    println!("{}", max_value);
+}
+
+#[test]
+fn test_maximum_triangle_path_sum() {
+    let mut vector = TRIANGLE.split("\n")
+                             .map(|x| {
+                                 x.split(" ")
+                                  .map(|s: &str| s.parse::<u32>().unwrap())
+                                  .collect::<Vec<u32>>()
+                             })
+                             .collect::<Vec<Vec<u32>>>();
+
+    let max_value = max_path(&mut vector);
+
+    assert_eq!(1320, max_value);
+}

--- a/src/md5.rs
+++ b/src/md5.rs
@@ -1,0 +1,12 @@
+// http://rosettacode.org/wiki/MD5
+
+extern crate crypto;
+
+use crypto::digest::Digest;
+use crypto::md5::Md5;
+
+fn main() {
+    let mut sh = Md5::new();
+    sh.input_str("The quick brown fox jumped over the lazy dog's back");
+    println!("{}", sh.result_str());
+}

--- a/src/metaprogramming.rs
+++ b/src/metaprogramming.rs
@@ -1,0 +1,78 @@
+// http://rosettacode.org/wiki/Metaprogramming
+
+//! Rust supports extensive metaprogramming via macros. Note that rust macros differ from, say, C
+//! preprocessor macros in that they are not mere text substitution (so operator precedence is
+//! preserved and name shadowing is not an issue). Here is an example from [rustbyexample.com] that
+//! implements and tests the `+=`, `-=`, and `*=` operators for Vectors.
+
+use std::ops::{Add, Mul, Sub};
+
+macro_rules! assert_equal_len {
+    // The `tt` (token tree) designator is used for
+    // operators and tokens.
+    ($a:ident, $b: ident, $func:ident, $op:tt) => (
+        assert!($a.len() == $b.len(),
+                "{:?}: dimension mismatch: {:?} {:?} {:?}",
+                stringify!($func),
+                ($a.len(),),
+                stringify!($op),
+                ($b.len(),));
+    )
+}
+
+macro_rules! op {
+    ($func:ident, $bound:ident, $op:tt, $method:ident) => (
+        fn $func<T: $bound<T, Output=T> + Copy>(xs: &mut Vec<T>, ys: &Vec<T>) {
+            assert_equal_len!(xs, ys, $func, $op);
+
+            for (x, y) in xs.iter_mut().zip(ys.iter()) {
+                *x = $bound::$method(*x, *y);
+                // *x = x.$method(*y);
+            }
+        }
+    )
+}
+
+// Implement `add_assign`, `mul_assign`, and `sub_assign` functions.
+op!(add_assign, Add, +=, add);
+op!(mul_assign, Mul, *=, mul);
+op!(sub_assign, Sub, -=, sub);
+
+fn main() {
+    let mut x = vec![2; 3];
+    let a = vec![1, 2, 3];
+    let b = vec![4, 5, 6];
+    let c = vec![7, 8, 9];
+
+    add_assign(&mut x, &a);
+    mul_assign(&mut x, &b);
+    sub_assign(&mut x, &c);
+
+    println!("{:?}", x);
+}
+
+mod test {
+    macro_rules! test {
+        ($func: ident, $x:expr, $y:expr, $z:expr) => {
+            #[test]
+            fn $func() {
+                use std::iter;
+
+                for size in 0usize..10 {
+                    let mut x: Vec<_> = iter::repeat($x).take(size).collect();
+                    let y: Vec<_> = iter::repeat($y).take(size).collect();
+                    let z: Vec<_> = iter::repeat($z).take(size).collect();
+
+                    super::$func(&mut x, &y);
+
+                    assert_eq!(x, z);
+                }
+            }
+        }
+    }
+
+    // Test `add_assign`, `mul_assign` and `sub_assign`
+    test!(add_assign, 1u32, 2u32, 3u32);
+    test!(mul_assign, 2u32, 3u32, 6u32);
+    test!(sub_assign, 3u32, 2u32, 1u32);
+}

--- a/src/multiplication_tables.rs
+++ b/src/multiplication_tables.rs
@@ -1,0 +1,30 @@
+// http://rosettacode.org/wiki/Multiplication_tables
+
+#![feature(range_inclusive)]
+
+use std::iter::range_inclusive;
+
+const LIMIT: i32 = 12;
+
+fn main() {
+    for i in range_inclusive(1, LIMIT) {
+        print!("{:3} ", i);
+    }
+    print!("\n");
+
+    for i in 0..LIMIT {
+        print!("----");
+    }
+    print!("+\n");
+
+    for i in range_inclusive(1, LIMIT) {
+        for j in range_inclusive(1, LIMIT) {
+            if j < i {
+                print!("    ")
+            } else {
+                print!("{:3} ", j * i)
+            }
+        }
+        println!("| {}", i);
+    }
+}

--- a/src/numerical_integration.rs
+++ b/src/numerical_integration.rs
@@ -1,0 +1,24 @@
+// http://rosettacode.org/wiki/Numerical_integration
+
+//! This is a partial solution and only implements trapezium integration.
+
+fn trapezium_integral<F>(f: F, range: std::ops::Range<f64>, n_steps: u32) -> f64
+    where F: Fn(f64) -> f64
+{
+    let step_size = (range.end - range.start) / n_steps as f64;
+
+    let mut integral = (f(range.start) + f(range.end)) / 2.;
+    let mut pos = range.start + step_size;
+    while pos < range.end {
+        integral += f(pos);
+        pos += step_size;
+    }
+    integral * step_size
+}
+
+fn main() {
+    println!("{}", trapezium_integral(|x| x.powi(3), 0.0..1.0, 100));
+    println!("{}", trapezium_integral(|x| 1.0 / x, 1.0..100.0, 1000));
+    println!("{}", trapezium_integral(|x| x, 0.0..5000.0, 5_000_000));
+    println!("{}", trapezium_integral(|x| x, 0.0..6000.0, 6_000_000));
+}

--- a/src/program_name.rs
+++ b/src/program_name.rs
@@ -1,0 +1,5 @@
+// http://rosettacode.org/wiki/Program_name
+
+fn main() {
+    println!("Program: {}", std::env::args().next().unwrap());
+}

--- a/src/queue/definition.rs
+++ b/src/queue/definition.rs
@@ -1,0 +1,174 @@
+// http://rosettacode.org/wiki/Queue/Definition
+
+//! This shows the implementation of a singly-linked queue with dequeue and enqueue. There are two
+//! peek implementations, one returns an immutable reference, the other returns a mutable one. This
+//! implementation also shows iteration over the Queue by value (consumes queue), immutable
+//! reference, and mutable reference.
+
+use std::ptr;
+
+pub struct Queue<T> {
+    head: Link<T>,
+
+    /// Raw, C-like pointer. Cannot be guaranteed safe
+    tail: *mut Item<T>,
+}
+
+type Link<T> = Option<Box<Item<T>>>;
+
+struct Item<T> {
+    elem: T,
+    next: Link<T>,
+}
+
+pub struct IntoIter<T>(Queue<T>);
+
+pub struct Iter<'a, T: 'a> {
+    next: Option<&'a Item<T>>,
+}
+
+pub struct IterMut<'a, T: 'a> {
+    next: Option<&'a mut Item<T>>,
+}
+
+
+impl<T> Queue<T> {
+    pub fn new() -> Self {
+        Queue {
+            head: None,
+            tail: ptr::null_mut(),
+        }
+    }
+
+    pub fn enqueue(&mut self, elem: T) {
+        let mut new_tail = Box::new(Item {
+            elem: elem,
+            next: None,
+        });
+
+        let raw_tail: *mut _ = &mut *new_tail;
+
+        if !self.tail.is_null() {
+            unsafe {
+                (*self.tail).next = Some(new_tail);
+            }
+        } else {
+            self.head = Some(new_tail);
+        }
+
+        self.tail = raw_tail;
+    }
+
+    pub fn dequeue(&mut self) -> Option<T> {
+        self.head.take().map(|head| {
+            let head = *head;
+            self.head = head.next;
+
+            if self.head.is_none() {
+                self.tail = ptr::null_mut();
+            }
+
+            head.elem
+        })
+    }
+
+    pub fn peek(&self) -> Option<&T> {
+        self.head.as_ref().map(|item| &item.elem)
+    }
+
+    pub fn peek_mut(&mut self) -> Option<&mut T> {
+        self.head.as_mut().map(|item| &mut item.elem)
+    }
+
+    pub fn into_iter(self) -> IntoIter<T> {
+        IntoIter(self)
+    }
+
+    pub fn iter(&self) -> Iter<T> {
+        Iter { next: self.head.as_ref().map(|item| &**item) }
+    }
+
+    pub fn iter_mut(&mut self) -> IterMut<T> {
+        IterMut { next: self.head.as_mut().map(|item| &mut **item) }
+    }
+}
+
+impl<T> Drop for Queue<T> {
+    fn drop(&mut self) {
+        let mut cur_link = self.head.take();
+        while let Some(mut boxed_item) = cur_link {
+            cur_link = boxed_item.next.take();
+        }
+    }
+}
+
+impl<T> Iterator for IntoIter<T> {
+    type Item = T;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.dequeue()
+    }
+}
+
+impl<'a, T> Iterator for Iter<'a, T> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next.map(|item| {
+            self.next = item.next.as_ref().map(|item| &**item);
+            &item.elem
+        })
+    }
+}
+
+impl<'a, T> Iterator for IterMut<'a, T> {
+    type Item = &'a mut T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next.take().map(|item| {
+            self.next = item.next.as_mut().map(|item| &mut **item);
+            &mut item.elem
+        })
+    }
+}
+
+fn main() {
+    // The standard library has a double-ended queue implementation
+    // (VecDeque<T>) which will work here.
+    use std::collections::VecDeque;
+
+    let mut deque = VecDeque::new();
+    deque.push_back("Element1");
+    deque.push_back("Element2");
+    deque.push_back("Element3");
+
+    assert_eq!(Some(&"Element1"), deque.front());
+    assert_eq!(Some("Element1"), deque.pop_front());
+    assert_eq!(Some("Element2"), deque.pop_front());
+    assert_eq!(Some("Element3"), deque.pop_front());
+    assert_eq!(None, deque.pop_front());
+
+    let mut queue = Queue::new();
+    queue.enqueue("Element1");
+    queue.enqueue("Element2");
+    queue.enqueue("Element3");
+
+    assert_eq!(Some(&"Element1"), queue.peek());
+    assert_eq!(Some("Element1"), queue.dequeue());
+    assert_eq!(Some("Element2"), queue.dequeue());
+    assert_eq!(Some("Element3"), queue.dequeue());
+    assert_eq!(None, queue.dequeue());
+}
+
+#[test]
+fn test_queue() {
+    let mut queue = Queue::new();
+    queue.enqueue("Element1");
+    queue.enqueue("Element2");
+    queue.enqueue("Element3");
+
+    assert_eq!(Some(&"Element1"), queue.peek());
+    assert_eq!(Some("Element1"), queue.dequeue());
+    assert_eq!(Some("Element2"), queue.dequeue());
+    assert_eq!(Some("Element3"), queue.dequeue());
+    assert_eq!(None, queue.dequeue());
+}

--- a/src/quine.rs
+++ b/src/quine.rs
@@ -1,0 +1,9 @@
+// http://rosettacode.org/wiki/Quine
+
+fn main() {
+    let x = "fn main() {\n    let x = ";
+    let y = "print!(\"{}{:?};\n    let y = {:?};\n    {}\", x, x, y, y)\n}\n";
+    print!("{}{:?};
+    let y = {:?};
+    {}", x, x, y, y)
+}

--- a/src/random_numbers.rs
+++ b/src/random_numbers.rs
@@ -1,0 +1,13 @@
+// http://rosettacode.org/wiki/Random_numbers
+
+extern crate rand;
+
+use rand::distributions::{Normal, IndependentSample};
+
+fn main() {
+    let normal = Normal::new(1.0, 0.5);
+    let mut rng = rand::thread_rng();
+
+    let rands = (0..1000).map(|_| normal.ind_sample(&mut rng)).collect::<Vec<_>>();
+    println!("{:?}", rands);
+}

--- a/src/range_extraction.rs
+++ b/src/range_extraction.rs
@@ -1,0 +1,64 @@
+// http://rosettacode.org/wiki/Range_extraction
+
+#![feature(zero_one)]
+
+use std::num::One;
+
+use std::ops::Add;
+
+struct RangeFinder<'a, T: 'a> {
+    index: usize,
+    length: usize,
+    arr: &'a [T],
+}
+
+impl<'a, T> Iterator for RangeFinder<'a, T>
+    where T: PartialEq + Add<T, Output = T> + Copy + One
+{
+    type Item = (T,  Option<T>);
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index == self.length {
+            return None;
+        }
+        let lo = self.index;
+        while self.index < self.length - 1 &&
+              self.arr[self.index + 1] == self.arr[self.index] + T::one() {
+            self.index += 1
+        }
+        let hi = self.index;
+        self.index += 1;
+        if hi - lo > 1 {
+            Some((self.arr[lo], Some(self.arr[hi])))
+        } else {
+            if hi - lo == 1 {
+                self.index -= 1
+            }
+            Some((self.arr[lo], None))
+        }
+    }
+}
+
+impl<'a, T> RangeFinder<'a, T> {
+    fn new(a: &'a [T]) -> Self {
+        RangeFinder {
+            index: 0,
+            arr: a,
+            length: a.len(),
+        }
+    }
+}
+
+fn main() {
+    let n = [0, 1, 2, 3];
+
+    for (i, (lo, hi)) in RangeFinder::new(&n).enumerate() {
+        if i > 0 {
+            print!(", ")
+        }
+        print!("{}", lo);
+        if hi.is_some() {
+            print!("-{}", hi.unwrap())
+        }
+    }
+    println!("");
+}

--- a/src/real_constants_and_functions.rs
+++ b/src/real_constants_and_functions.rs
@@ -1,0 +1,26 @@
+// http://rosettacode.org/wiki/Real_constants_and_functions
+
+use std::f64::consts::*;
+
+fn main() {
+    // e (base of the natural logarithm)
+    let mut x = E;
+    // π
+    x += PI;
+    // square root
+    x = x.sqrt();
+    // logarithm (any base allowed)
+    x = x.ln();
+    // ceiling (smallest integer not less than this number--not the same as round up)
+    x = x.ceil();
+    // exponential (ex)
+    x = x.exp();
+    // absolute value (a.k.a. "magnitude")
+    x = x.abs();
+    // floor (largest integer less than or equal to this number--not the same as truncate or int)
+    x = x.floor();
+    // power (xy)
+    x = x.powf(x);
+
+    assert_eq!(x, 4.0);
+}

--- a/src/return_multiple_values.rs
+++ b/src/return_multiple_values.rs
@@ -1,0 +1,10 @@
+// http://rosettacode.org/wiki/Return_multiple_values
+
+fn multi_hello() -> (&'static str, i32) {
+    ("Hello", 42)
+}
+
+fn main() {
+    let (string, num) = multi_hello();
+    println!("{}, {}", string, num);
+}

--- a/src/search_a_list.rs
+++ b/src/search_a_list.rs
@@ -1,0 +1,13 @@
+// http://rosettacode.org/wiki/Search_a_list
+
+fn main() {
+    let haystack = vec!["Zig", "Zag", "Wally", "Ronald", "Bush", "Krusty", "Charlie", "Bush",
+                        "Boz", "Zag"];
+
+    println!("First occurence of 'Bush' at {:?}",
+             haystack.iter().position(|s| *s == "Bush"));
+    println!("Last occurence of 'Bush' at {:?}",
+             haystack.iter().rposition(|s| *s == "Bush"));
+    println!("First occurence of 'Rob' at {:?}",
+             haystack.iter().position(|s| *s == "Rob"));
+}

--- a/src/singly_linked_list/element_definition.rs
+++ b/src/singly_linked_list/element_definition.rs
@@ -1,0 +1,45 @@
+// http://rosettacode.org/wiki/Singly-linked_list/Element_definition
+
+#![allow(dead_code)]
+
+//! Rust's `Option<T>` type makes the definition of a singly-linked list trivial. The use of
+//! `Box<T>` (an owned pointer) is necessary because it has a known size, thus making sure the
+//! struct that contains it can have a finite size.
+//!
+//! ```{rust}
+//! struct Node<T> {
+//!     elem: T,
+//!     next: Option<Box<Node<T>>>,
+//! }
+//! ```
+//!
+//! However, the above example would not be suitable for a library because, first and foremost, it
+//! is private by default but simply making it public would not allow for any encapsulation.
+
+/// Type alias
+type Link<T> = Option<Box<Node<T>>>;
+
+/// User-facing interface for list
+pub struct List<T> {
+    head: Link<T>,
+}
+
+/// Private implementation of Node
+struct Node<T> {
+    elem: T,
+    next: Link<T>,
+}
+
+impl<T> List<T> {
+    /// List constructor
+    #[inline]
+    pub fn new() -> Self {
+        List { head: None }
+    }
+
+    // Add other methods here...
+}
+
+fn main() {
+    let _ = List::<i32>::new();
+}

--- a/src/singly_linked_list/element_insertion.rs
+++ b/src/singly_linked_list/element_insertion.rs
@@ -1,0 +1,33 @@
+// http://rosettacode.org/wiki/Singly-linked_list/Element_insertion
+
+#![allow(dead_code)]
+
+type Link<T> = Option<Box<Node<T>>>;
+
+pub struct List<T> {
+    head: Link<T>,
+}
+
+struct Node<T> {
+    elem: T,
+    next: Link<T>,
+}
+
+impl<T> List<T> {
+    pub fn new() -> Self {
+        List { head: None }
+    }
+
+    pub fn push(&mut self, elem: T) {
+        let new_node = Box::new(Node {
+            elem: elem,
+            next: self.head.take(),
+        });
+        self.head = Some(new_node);
+    }
+}
+
+fn main() {
+    let mut list = List::new();
+    list.push(1);
+}

--- a/src/singly_linked_list/traversal.rs
+++ b/src/singly_linked_list/traversal.rs
@@ -1,0 +1,96 @@
+// http://rosettacode.org/wiki/Singly-linked_list/Traversal
+
+type Link<T> = Option<Box<Node<T>>>;
+
+pub struct List<T> {
+    head: Link<T>,
+}
+
+struct Node<T> {
+    elem: T,
+    next: Link<T>,
+}
+
+impl<T> List<T> {
+    pub fn new() -> Self {
+        List { head: None }
+    }
+
+    pub fn push(&mut self, elem: T) {
+        let new_node = Box::new(Node {
+            elem: elem,
+            next: self.head.take(),
+        });
+        self.head = Some(new_node);
+    }
+}
+
+/// Iteration by value (simply empties the list as the caller now owns all values)
+pub struct IntoIter<T>(List<T>);
+
+impl<T> Iterator for IntoIter<T> {
+    type Item = T;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.head.take().map(|node| {
+            let node = *node;
+            self.0.head = node.next;
+            node.elem
+        })
+    }
+}
+
+/// Iteration by immutable reference
+pub struct Iter<'a, T: 'a> {
+    next: Option<&'a Node<T>>,
+}
+
+impl<'a, T> Iterator for Iter<'a, T> {
+    type Item = &'a T;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next.take().map(|node| {
+            self.next = node.next.as_ref().map(|node| &**node);
+            &node.elem
+        })
+    }
+}
+
+/// Iteration by mutable reference
+pub struct IterMut<'a, T: 'a> {
+    next: Option<&'a mut Node<T>>,
+}
+
+impl<'a, T> Iterator for IterMut<'a, T> {
+    type Item = &'a mut T;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next.take().map(|node| {
+            self.next = node.next.as_mut().map(|node| &mut **node);
+            &mut node.elem
+        })
+    }
+}
+
+/// Methods implemented for List<T>
+impl<T> List<T> {
+    pub fn into_iter(self) -> IntoIter<T> {
+        IntoIter(self)
+    }
+
+    pub fn iter<'a>(&'a self) -> Iter<'a, T> {
+        Iter { next: self.head.as_ref().map(|node| &**node) }
+    }
+
+    pub fn iter_mut(&mut self) -> IterMut<T> {
+        IterMut { next: self.head.as_mut().map(|node| &mut **node) }
+    }
+}
+
+fn main() {
+    let mut list = List::new();
+    list.push(1);
+    list.push(2);
+    list.push(3);
+
+    for item in list.iter() {
+        println!("{}", item);
+    }
+}

--- a/src/sockets.rs
+++ b/src/sockets.rs
@@ -1,0 +1,12 @@
+// http://rosettacode.org/wiki/Sockets
+
+use std::io::prelude::*;
+use std::net::TcpStream;
+
+fn main() {
+    // Open a tcp socket connecting to 127.0.0.1:256, no error handling (unwrap)
+    let mut my_stream = TcpStream::connect("127.0.0.1:256").unwrap();
+
+    // Write 'hello socket world' to the stream
+    write!(my_stream, "hello socket world").unwrap();
+} // <- my_stream's drop function gets called, which closes the socket

--- a/src/string_case.rs
+++ b/src/string_case.rs
@@ -1,0 +1,6 @@
+// http://rosettacode.org/wiki/String_case
+
+fn main() {
+    println!("{}", "jalapeño".to_uppercase()); // JALAPEÑO
+    println!("{}", "JALAPEÑO".to_lowercase()); // jalapeño
+}

--- a/src/string_interpolation_included.rs
+++ b/src/string_interpolation_included.rs
@@ -1,0 +1,13 @@
+// http://rosettacode.org/wiki/String_interpolation_(included)
+
+//! Rust has very powerful string interpolation. [Documentation here][doc]
+//!
+//! [doc]: https://doc.rust-lang.org/stable/std/fmt/
+
+fn main() {
+    println!("Mary had a {} lamb", "little");
+    // You can specify order
+    println!("{1} had a {0} lamb", "little", "Mary");
+    // Or named arguments if you prefer
+    println!("{name} had a {adj} lamb", adj = "little", name = "Mary");
+}

--- a/src/unix/ls.rs
+++ b/src/unix/ls.rs
@@ -1,4 +1,4 @@
-// http://rosettacode.org/wiki/Unix/ls#Rust
+// http://rosettacode.org/wiki/Unix/ls
 
 //! Works only with correct paths or no arguments at all
 

--- a/src/user_input/text.rs
+++ b/src/user_input/text.rs
@@ -1,0 +1,36 @@
+// http://rosettacode.org/wiki/User_input/Text
+
+//! This program demonstrates proper error handling.
+
+use std::io::{self, Write};
+use std::fmt::Display;
+use std::process;
+
+fn grab_input(msg: &str) -> io::Result<String> {
+    let mut buf = String::new();
+    print!("{}: ", msg);
+    try!(io::stdout().flush());
+
+    try!(io::stdin().read_line(&mut buf));
+    Ok(buf)
+}
+
+fn exit_err<T: Display>(msg: T, code: i32) -> ! {
+    let _ = writeln!(&mut io::stderr(), "Error: {}", msg);
+    process::exit(code)
+}
+
+fn main() {
+    let s = grab_input("Give me a string")
+                .unwrap_or_else(|e| exit_err(&e, e.raw_os_error().unwrap_or(-1)));
+
+    println!("You entered: {}", s.trim());
+
+    let n: i32 = grab_input("Give me an integer")
+                     .unwrap_or_else(|e| exit_err(&e, e.raw_os_error().unwrap_or(-1)))
+                     .trim()
+                     .parse()
+                     .unwrap_or_else(|e| exit_err(&e, 2));
+
+    println!("You entered: {}", n);
+}


### PR DESCRIPTION
Used the same strategy for this PR as #433.

More progress towards #402, #170.

# Changes
- Added 47 implementations
- Added two additional features: `--with-gtk` and `--with-ncurses` which compile tasks with those libraries enabled. Without the features enabled, the tasks are no-ops.
- Made the regex for parsing task headers stricter (to make things easier for coverage)
- Fixed a link in the README.

# Remaining work
- There appears to be a few tasks implemented on the wiki that aren't being picked up by coverage
- The Y-Combinator implementation currently does not compile