### PR TITLE
improve test coverage accuracy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,4 @@ script:
 # Generate Docs and coverage
 after_success:
     - travis-cargo doc-upload
-    - travis-cargo coveralls --no-sudo
+    - travis-cargo coveralls --no-sudo "-C link-dead-code"


### PR DESCRIPTION
Supplying this argument to `travis-cargo` *should* make our coverage more accurate. No way to test it other than triggering a CI build, though?