### PR TITLE
Fix the main crate failing to build on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,9 @@ environment:
     BITS: 32
   - TARGET: i686-pc-windows-gnu
     BITS: 32
+
+shallow_clone: true
+
 install:
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-${env:TARGET}.exe"
   - rust-nightly-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"

--- a/src/handle_a_signal.rs
+++ b/src/handle_a_signal.rs
@@ -8,6 +8,7 @@ use std::sync::atomic::{AtomicBool, ATOMIC_BOOL_INIT, Ordering};
 use std::thread;
 use std::time::Duration;
 
+#[cfg(unix)]
 use libc::SIGINT;
 
 #[cfg(unix)]

--- a/src/input_is_terminal.rs
+++ b/src/input_is_terminal.rs
@@ -1,6 +1,7 @@
 // http://rosettacode.org/wiki/Check_input_device_is_a_terminal
 extern crate libc;
 
+#[cfg(unix)]
 fn main() {
     let istty = unsafe { libc::isatty(libc::STDIN_FILENO as i32) } != 0;
     if istty {
@@ -8,4 +9,9 @@ fn main() {
     } else {
         println!("stdin is not tty");
     }
+}
+
+#[cfg(not(unix))]
+fn main() {
+    unimplemented!();
 }

--- a/src/output_is_terminal.rs
+++ b/src/output_is_terminal.rs
@@ -1,6 +1,7 @@
 // http://rosettacode.org/wiki/Check_output_device_is_a_terminal
 extern crate libc;
 
+#[cfg(unix)]
 fn main() {
     let istty = unsafe { libc::isatty(libc::STDOUT_FILENO as i32) } != 0;
     if istty {
@@ -8,4 +9,9 @@ fn main() {
     } else {
         println!("stdout is not tty");
     }
+}
+
+#[cfg(not(unix))]
+fn main() {
+    unimplemented!();
 }


### PR DESCRIPTION
Hello.

Attempting to `cargo build` the main `rust-rosetta` crate on Windows currently fails due to several solutions that use Unix-specific constructs. These changes should resolve this.