### PR TITLE
use inclusive range for downward_for

### DIFF
--- a/src/loops/downward_for.rs
+++ b/src/loops/downward_for.rs
@@ -3,7 +3,7 @@
 #![feature(inclusive_range_syntax)]
 
 fn main() {
-    for i in (1..10).rev() {
+    for i in (1...10).rev() {
         println!("{}", i);
     }
 }


### PR DESCRIPTION
The previous commit accidentally used an exclusive range. See #476.