### PR TITLE
Remove compile warnings for signal handling solution

### DIFF
--- a/src/handle_a_signal.rs
+++ b/src/handle_a_signal.rs
@@ -3,16 +3,13 @@
 extern crate libc;
 extern crate time;
 
-use std::mem;
-use std::sync::atomic::{AtomicBool, ATOMIC_BOOL_INIT, Ordering};
-use std::thread;
-use std::time::Duration;
-
-#[cfg(unix)]
-use libc::SIGINT;
-
 #[cfg(unix)]
 fn main() {
+    use std::mem;
+    use std::sync::atomic::{AtomicBool, ATOMIC_BOOL_INIT, Ordering};
+    use std::thread;
+    use std::time::Duration;
+    use libc::SIGINT;
     // The time between ticks of our counter.
     let duration = Duration::from_secs(1) / 2;
     // "SIGINT received" global variable.


### PR DESCRIPTION
Hello.

I've simply moved some code for the signal handling solution such that compilation of the `rust-rosetta` crate doesn't yield warnings in order to keep build logs nice and clean.