### PR TITLE
Support 64-bit MSVC Rust configuration for Windows builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,9 @@
 environment:
   OPENSSL_LIBS: ssleay32:libeay32
+  RUST_DIR: C:\Rust\
   matrix:
-  # 64-bit MSVC builds currently hang when trying to run the coverage crate
-  # lib test. Suppressed this configuration for now to allow for the overall
-  # build to succeed
-  # - TARGET: x86_64-pc-windows-msvc
-  #  BITS: 64
+  - TARGET: x86_64-pc-windows-msvc
+    BITS: 64
   - TARGET: i686-pc-windows-msvc
     BITS: 32
   - TARGET: i686-pc-windows-gnu
@@ -14,9 +12,9 @@ environment:
 shallow_clone: true
 
 install:
-  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-${env:TARGET}.exe"
-  - rust-nightly-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
-  - SET PATH=%PATH%;C:\Program Files (x86)\Rust\bin
+  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-${env:TARGET}.msi"
+  - msiexec /i rust-nightly-%TARGET%.msi /quiet /passive /qn /norestart INSTALLDIR=%RUST_DIR%
+  - SET PATH=%PATH%;%RUST_DIR%\bin
   - SET PATH=%PATH%;C:\MinGW\bin
   - SET OPENSSL_INCLUDE_DIR=C:\OpenSSL-Win%BITS%\include
   - SET OPENSSL_LIB_DIR=C:\OpenSSL-Win%BITS%\lib
@@ -26,4 +24,9 @@ install:
 build: false
 
 test_script:
+  # The copy helps DLL search resolve compatible versions of OpenSSL DLLs for
+  # the build target executable. This works around the AppVeyor build
+  # environment preferring to load DLLs that would be incompatible with 64-bit
+  # build configurations.
+  - ps: cp -path "C:\OpenSSL-Win${env:BITS}\*.dll" -destination (md -force "$env:APPVEYOR_BUILD_FOLDER\target\debug")
   - cargo test


### PR DESCRIPTION
Hello.

Good news, I've finally managed to get a 64-bit build configuration for Windows to run the `lib` test for the `rust-rosetta` crate successfully. After getting some useful feedback from AppVeyor support, it turns out the freeze was the result of an error dialog that appears during test execution. The dialog doesn't get closed and caused builds to time out after 60 minutes, thus the failures.

I'm not absolutely certain, but from what I've gathered, the error was to do with the test executable loading incompatible versions of OpenSSL dynamic libraries during run-time. My workaround for this is to copy the relevant libraries from their installed locations into the build target directory. Upon test execution, they should be preferred by Windows standard DLL search order.

Note that I was only able to get the 64-bit MSVC flavour working. I ran into the `rust-crypto` crate failing to compile for the GNU version. If anybody is interested in the trace for this, see:

https://ci.appveyor.com/project/miqid/rust-rosetta/build/0.0.21/job/qs6q1r2ub8edaktm

```bash
running: "gcc.exe" "-O0" "-ffunction-sections" "-fdata-sections" "-g" "-m64" "-o" "C:\\projects\\rust-rosetta\\target\\debug\\build\\rust-crypto-97872ea539a059cd\\out\\src\\util_helpers.o" "-c" "src/util_helpers.c"
ExitStatus(ExitStatus(1))
 
command did not execute successfully, got: exit code: 1

--- stderr
src/util_helpers.c:1:0: sorry, unimplemented: 64-bit mode not compiled in
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 ^
```