### PR TITLE
Fix failing 64-bit MSVC AppVeyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,5 +30,9 @@ test_script:
   # build configurations.
   - ps: cp -path "C:\OpenSSL-Win${env:BITS}\*.dll" -destination (md -force "$env:APPVEYOR_BUILD_FOLDER\target\debug")
   - cargo test
+  # Also copy the correct OpenSSL DLLs to the build target path of the coverage
+  # crate. They should be preferred by DLL resolution to prevent platform
+  # binary mismatch errors during runtime.
+  - ps: cp -path "C:\OpenSSL-Win${env:BITS}\*.dll" -destination (md -force "$env:APPVEYOR_BUILD_FOLDER\coverage\target\debug")
   - cd coverage
   - cargo test


### PR DESCRIPTION
Addresses #519.

I used the same work around I previously made to get around the `rust-rosetta` crate failing builds with a 64-bit MSVC configuration.

Recent AppVeyor build failures would've been due to e0e6e54, which adds testing for the `coverage` crate to the builds.