### PR TITLE
update CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ env:
   global:
     - RUST_BACKTRACE=1
     - TRAVIS_CARGO_NIGHTLY_FEATURE=""
-    - RUSTFLAGS="-C link-dead-code"
-    - LD_LIBRARY_PATH="$TRAVIS_BUILD_DIR/target/debug/deps"
 
 # `sudo`-less apt install.
 addons:
@@ -20,9 +18,7 @@ addons:
       - libelf-dev
       - libdw-dev
 
-cache:
-  directories:
-    - $HOME/.cargo
+cache: cargo
 
 # Load `travis-cargo`
 before_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,10 @@ environment:
 
 shallow_clone: true
 
+cache:
+  - target
+  - '%USERPROFILE%\.cargo'
+
 install:
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-${env:TARGET}.msi"
   - msiexec /i rust-nightly-%TARGET%.msi /quiet /passive /qn /norestart INSTALLDIR=%RUST_DIR%


### PR DESCRIPTION
Removed environment variables that are now set automatically by `travis-cargo`.

Also, used travis' built-in cargo cache, which also includes compiled artifacts. This should make our builds somewhat faster when dependencies haven't changed.

Caching is enabled on Appveyor as well.