### PR TITLE
Correct address-of-a-variable/src/main.rs

### DIFF
--- a/tasks/address-of-a-variable/src/main.rs
+++ b/tasks/address-of-a-variable/src/main.rs
@@ -5,7 +5,7 @@ fn main() {
 
     // Get the value at a certain memory address
     let address = &var as *const i32;
-    println!("value at {:p}: {:?}", &address, var);
+    println!("value at {:p}: {:?}", address, var);
 
     // Set the value at a certain memory address
     unsafe {


### PR DESCRIPTION
Minor address format fix