### PR TITLE
remove `skip_cleanup` parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ before_deploy:
 
 deploy:
   provider: pages
-  skip_cleanup: true
   github_token: "$GITHUB_TOKEN"
   on:
     branch: master


### PR DESCRIPTION
This should allow travis to clean up all the leftover build artifacts,
giving us enough space to publish the json.