### PR TITLE
clean up before deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ script:
   - cargo test --all
 
 before_deploy:
+  - cargo clean
   - cargo run --release --bin coverage -- --json coverage.json
 
 deploy:


### PR DESCRIPTION
The travis build is failing the deploy, complaining that there isn't
enough space left on the device. It should be possible to mitigate this
by cleaning any constructed artifacts before the deploy.

EDIT: Apparently deploy isn't triggered for PRs (well, that makes sense), so I'm not sure that I can test this without it being merged...