### PR TITLE
Update and use ring for bitcoin address validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ version = "0.1.0"
 name = "address-validation"
 version = "0.1.0"
 dependencies = [
- "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3454,13 +3454,15 @@ version = "0.1.0"
 
 [[package]]
 name = "ring"
-version = "0.13.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3707,7 +3709,7 @@ version = "0.1.0"
 name = "sha-256"
 version = "0.1.0"
 dependencies = [
- "ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3819,6 +3821,11 @@ version = "0.1.0"
 dependencies = [
  "regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "stable_deref_trait"
@@ -4851,7 +4858,7 @@ version = "0.1.0"
 "checksum regex-syntax 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8c2f35eedad5295fdf00a63d7d4b238135723f92b434ec06774dad15c7ab0861"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum reqwest 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)" = "e542d9f077c126af32536b6aacc75bb7325400eab8cd0743543be5d91660780d"
-"checksum ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2c4db68a2e35f3497146b7e4563df7d4773a2433230c5e4b448328e31740458a"
+"checksum ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)" = "426bc186e3e95cac1e4a4be125a4aca7e84c2d616ffc02244eef36e2a60a093c"
 "checksum rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
 "checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
@@ -4875,6 +4882,7 @@ version = "0.1.0"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"
 "checksum smithay-client-toolkit 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2051bffc6cbf271176e8ba1527f801b6444567daee15951ff5152aaaf7777b2f"
+"checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum string 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b639411d0b9c738748b5397d5ceba08e648f4f1992231aa859af1a017f31f60b"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"

--- a/tasks/bitcoin/address-validation/Cargo.toml
+++ b/tasks/bitcoin/address-validation/Cargo.toml
@@ -6,4 +6,4 @@ version = "0.1.0"
 url = "http://rosettacode.org/wiki/Bitcoin/address_validation"
 
 [dependencies]
-rust-crypto = "0.2"
+ring = "0.14"

--- a/tasks/bitcoin/address-validation/src/main.rs
+++ b/tasks/bitcoin/address-validation/src/main.rs
@@ -1,7 +1,6 @@
-extern crate crypto;
+extern crate ring;
 
-use crypto::digest::Digest;
-use crypto::sha2::Sha256;
+use ring::digest::{digest, SHA256};
 
 /// Decodes a base58-encoded string into an array of bytes.
 fn decode_base58(address: &str) -> Result<Vec<u8>, &'static str> {
@@ -32,18 +31,10 @@ fn decode_base58(address: &str) -> Result<Vec<u8>, &'static str> {
 
 /// Hashed the input with the SHA-256 algorithm twice, and returns the output.
 fn double_sha256(bytes: &[u8]) -> Vec<u8> {
-    let mut hasher = Sha256::new();
+    let digest_1 = digest(&SHA256, bytes);
 
-    hasher.input(bytes);
-    let mut digest_1 = vec![0; 32];
-    hasher.result(&mut digest_1);
-    hasher.reset();
-
-    hasher.input(&digest_1);
-    let mut digest_2 = vec![0; 32];
-    hasher.result(&mut digest_2);
-
-    digest_2
+    let digest_2 = digest(&SHA256, digest_1.as_ref());
+    digest_2.as_ref().to_vec()
 }
 
 /// Validates a bitcoin address.

--- a/tasks/sha-256/Cargo.toml
+++ b/tasks/sha-256/Cargo.toml
@@ -6,4 +6,4 @@ version = "0.1.0"
 url = "http://rosettacode.org/wiki/SHA-256"
 
 [dependencies]
-ring = "0.13"
+ring = "0.14"


### PR DESCRIPTION
I updated the ring package from `0.13` to `0.14` and used its `SHA256` hashing algorithm for bitcoin address validation. As stated in #637. 