### PR TITLE
add a shell.nix for easier nix development

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,19 @@
+# copied expressions from https://nixos.wiki/wiki/Rust
+# and Mozilla's nix overlay README
+let
+  moz_overlay = import (builtins.fetchTarball https://github.com/mozilla/nixpkgs-mozilla/archive/master.tar.gz);
+  nixpkgs = import <nixpkgs> { overlays = [ moz_overlay ]; };
+in
+  with nixpkgs;
+  stdenv.mkDerivation {
+    name = "rust_nightly_shell";
+    buildInputs = [
+      nixpkgs.latest.rustChannels.nightly.rust
+      openssl
+    ];
+
+    shellHook = ''
+      export OPENSSL_DIR="${openssl.dev}"
+      export OPENSSL_LIB_DIR="${openssl.out}/lib"
+      '';
+  }


### PR DESCRIPTION
This lets anyone using nix simply invoke `nix-shell` to load the nightly version of nix and properly load the openssl library paths that some crates rely upon ([openssl-sys](https://crates.io/crates/openssl-sys)).

Used the rust powered [nixpkgs-fmt ](https://nix-community.github.io/nixpkgs-fmt/)to format and it worked great.